### PR TITLE
Run tests against py2.7 instead of 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "2.7"
 os:
   - linux
 before_install:


### PR DESCRIPTION
3.6 isnt available on windows. For now just focus on supporting 2.7