### PR TITLE
General revision specifier

### DIFF
--- a/python/checkout.py
+++ b/python/checkout.py
@@ -8,7 +8,8 @@ import subprocess
 import perforce
 
 __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
-__LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
+# https://github.com/buildkite/cli/blob/e8aac4bedf34cd8084a3ae7a4ab7812c611d0310/local/run.go#L403
+__LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local' 
 __REVISION_METADATA__ = 'buildkite:perforce:revision'
 
 def get_build_revision():

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -8,6 +8,7 @@ import subprocess
 import perforce
 
 __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
+__LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
 __REVISION_METADATA__ = 'buildkite:perforce:revision'
 
 def get_build_revision():
@@ -47,7 +48,7 @@ def main():
 
     revision = get_build_revision()
     if not revision: # No revision set, must be our responsibility.
-        if os.environ['BUILDKITE_COMMIT'] == 'HEAD':
+        if os.environ['BUILDKITE_COMMIT'] == 'HEAD' or __LOCAL_RUN__:
             revision = repo.head()
         else:
             revision = os.environ['BUILDKITE_COMMIT']

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -83,7 +83,7 @@ class Repo:
 
     def head(self):
         """Get current head revision"""
-        return '#%s' % self.perforce.run_counter("maxCommitChange")[0]['value']
+        return '@%s' % self.perforce.run_counter("maxCommitChange")[0]['value']
 
     def sync(self, revision=None):
         """Sync the workspace"""

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -80,7 +80,7 @@ def test_checkout():
 
     with tempfile.TemporaryDirectory(prefix="bk-p4-test-") as client_root:
         repo = perforce.Repo(root=client_root)
-        assert repo.head() == "#1", "Unexpected head revision"
+        assert repo.head() == "@1", "Unexpected head revision"
 
         assert os.listdir(client_root) == [], "Workspace should be empty"
         repo.sync()
@@ -95,7 +95,7 @@ def test_checkout():
         assert os.listdir(client_root) == [
             "file.txt"], "Failed to restore workspace file"
 
-        repo.sync(revision='#0')
+        repo.sync(revision='@0')
         assert os.listdir(client_root) == [], "Workspace file wasn't de-synced"
 
 # def test_bad_configs():


### PR DESCRIPTION
Fixes a bug where syncing to `#N` doesn't work if your files don't have a revision N

`@N` syncs to the state immediately after changelist N was submitted, which is much closer to a git sha