### PR TITLE
Clobber nonwriteable files in workspace

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -62,6 +62,10 @@ class P4Repo:
         if self.view:
             client._view = self.view
 
+        # overwrite writeable-but-unopened files
+        # (e.g. interrupted syncs, artefacts that have been checked-in)
+        client._options = client._options.replace('noclobber', 'clobber')
+
         self.perforce.save_client(client)
 
         self.perforce.client = clientname
@@ -85,7 +89,7 @@ class P4Repo:
         """Get current head revision"""
         return '@%s' % self.perforce.run_counter("maxCommitChange")[0]['value']
 
-    def sync(self, revision=None):
+    def sync(self, *args, revision=None):
         """Sync the workspace"""
         self._setup_client()
-        return self.perforce.run_sync('//...%s' % (revision or ''))
+        return self.perforce.run_sync(*args, '//...%s' % (revision or ''))

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -102,14 +102,6 @@ def test_checkout():
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Hello World\n", "Unexpected content in workspace file"
 
-        os.remove(os.path.join(client_root, "file.txt"))
-        open(os.path.join(client_root, "added.txt"), 'a').close()
-        assert os.listdir(client_root) == [
-            "added.txt"], "Workspace files in unexpected state prior to clean"
-        repo.clean()
-        assert os.listdir(client_root) == [
-            "file.txt"], "Failed to restore workspace file"
-
         repo.sync(revision='@0')
         assert os.listdir(client_root) == [], "Workspace file wasn't de-synced"
 
@@ -126,6 +118,31 @@ def test_checkout_stream():
             "file.txt"], "Workspace file wasn't synced"
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Hello Stream World\n", "Unexpected content in workspace file"            
+
+def test_workspace_recovery():
+    """Test that we can detect and recover from various workspace snafus"""
+    setup_server(from_zip='server.zip')
+
+    with tempfile.TemporaryDirectory(prefix="bk-p4-test-") as client_root:
+        repo = P4Repo(root=client_root)
+
+        # clobber writeable file
+        # partially synced writeable files may be left in the workspace if a machine was shutdown mid-sync
+        with open(os.path.join(client_root, "file.txt"), 'w') as depotfile:
+            depotfile.write("Overwrite this file")
+        repo.sync() # By default, would raise 'cannot clobber writable file'
+        with open(os.path.join(client_root, "file.txt")) as content:
+            assert content.read() == "Hello World\n", "Unexpected content in workspace file"
+
+        # p4 clean
+        os.remove(os.path.join(client_root, "file.txt"))
+        open(os.path.join(client_root, "added.txt"), 'a').close()
+        assert os.listdir(client_root) == [
+            "added.txt"], "Workspace files in unexpected state prior to clean"
+        repo.clean()
+        assert os.listdir(client_root) == [
+            "file.txt"], "Failed to restore workspace file with repo.clean()"
+
 
 # def test_bad_configs():
 #     P4Repo('port', stream='stream', view=['view'])


### PR DESCRIPTION
* Split unit tests up a bit more
* Set workspace flag to allow overwriting writeable files