### PR TITLE
Allow configuring parallel sync. Off by default.

### DIFF
--- a/.buildkite/local-pipeline.yml
+++ b/.buildkite/local-pipeline.yml
@@ -7,3 +7,4 @@ steps:
           p4user: banana
           view: //depot/... ...
           root: p4_workspace
+          parallel: 2

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -12,6 +12,7 @@ __REVISION_ANNOTATION__ = "Revision: %s"
 
 
 def get_env():
+    """Get env vars passed in via plugin config"""
     env = {
         'P4PORT': os.environ.get('P4PORT') or os.environ.get('BUILDKITE_REPO')
     }
@@ -22,6 +23,7 @@ def get_env():
     return env
 
 def get_config():
+    """Get configuration which will be passed directly to perforce.P4Repo as kwargs"""
     conf = {}
     conf['root'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_ROOT') or os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH')
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -26,6 +26,7 @@ def get_config():
     conf['root'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_ROOT') or os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH')
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
     conf['stream'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_STREAM')
+    conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 0
 
     # Coerce view into pairs of [depot client] paths
     view_parts = conf['view'].split(' ')

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -14,7 +14,7 @@ def main():
     os.environ.update(get_env())
     config = get_config()
 
-    repo = P4Repo(root=config['root'], stream=config['stream'], view=config['view'])
+    repo = P4Repo(**config)
 
     revision = get_build_revision()
     if revision == 'HEAD':

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -11,7 +11,7 @@ from P4 import P4 # pylint: disable=import-error
 
 class P4Repo:
     """A class for manipulating perforce workspaces"""
-    def __init__(self, root=None, view=None, stream=None, parallel_threads=0):
+    def __init__(self, root=None, view=None, stream=None, parallel=0):
         """
         root: Directory in which to create the client workspace
         view: Client workspace mapping
@@ -20,7 +20,7 @@ class P4Repo:
         self.root = root
         self.stream = stream
         self.view = self._localize_view(view or [])
-        self.parallel_threads = parallel_threads
+        self.parallel = parallel
         self.perforce = P4()
         self.perforce.exception_level = 1  # Only errors are raised as exceptions
         logger = logging.getLogger("P4Python")
@@ -107,5 +107,5 @@ class P4Repo:
         """Sync the workspace"""
         self._setup_client()
         files = '//...%s' % (revision or '')
-        opts = '--parallel=threads=%s' % self.parallel_threads
+        opts = '--parallel=threads=%s' % self.parallel
         return self.perforce.run_sync(opts, files)

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -11,7 +11,7 @@ from P4 import P4 # pylint: disable=import-error
 
 class P4Repo:
     """A class for manipulating perforce workspaces"""
-    def __init__(self, root=None, view=None, stream=None):
+    def __init__(self, root=None, view=None, stream=None, parallel_threads=0):
         """
         root: Directory in which to create the client workspace
         view: Client workspace mapping
@@ -20,7 +20,7 @@ class P4Repo:
         self.root = root
         self.stream = stream
         self.view = self._localize_view(view or [])
-
+        self.parallel_threads = parallel_threads
         self.perforce = P4()
         self.perforce.exception_level = 1  # Only errors are raised as exceptions
         logger = logging.getLogger("P4Python")
@@ -106,4 +106,6 @@ class P4Repo:
     def sync(self, revision=None):
         """Sync the workspace"""
         self._setup_client()
-        return self.perforce.run_sync('//...%s' % (revision or ''))
+        files = '//...%s' % (revision or '')
+        opts = '--parallel=threads=%s' % self.parallel_threads
+        return self.perforce.run_sync(opts, files)

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -21,6 +21,7 @@ class P4Repo:
         self.stream = stream
         self.view = self._localize_view(view or [])
         self.parallel = parallel
+
         self.perforce = P4()
         self.perforce.exception_level = 1  # Only errors are raised as exceptions
         logger = logging.getLogger("P4Python")


### PR DESCRIPTION
Parallel processing is most effective with long-haul, high latency networks or with other network configuration that prevents the use of available bandwidth with a single TCP flow. 

Parallel processing might also be appropriate when working with large compressed binary files, where the client must perform substantial work to decompress the file.