### PR TITLE
Name clients with BUILDKITE_AGENT_NAME instead of _ID

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -41,7 +41,7 @@ class P4Repo:
         self.perforce.disconnect()
 
     def _get_clientname(self):
-        clientname = 'bk-p4-%s' % os.environ.get('BUILDKITE_AGENT_ID', socket.gethostname())
+        clientname = 'bk-p4-%s' % os.environ.get('BUILDKITE_AGENT_NAME', socket.gethostname())
         return re.sub(r'\W', '-', clientname)
 
     def _localize_view(self, view):


### PR DESCRIPTION
By default, this is %hostname%-%n. If somebody messes with that, it's their own problem.