### PR TITLE
BUILDKITE_CLEAN_CHECKOUT causes a p4 clean after checkout

### DIFF
--- a/.buildkite/local-pipeline.yml
+++ b/.buildkite/local-pipeline.yml
@@ -1,6 +1,8 @@
 steps:
   - label: "Test"
     command: echo "Hello World"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - ./.buildkite/plugins/perforce:
           p4port: localhost:1666

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -22,6 +22,8 @@ def main():
         set_build_revision(revision)
 
     repo.sync(revision=revision)
+    if os.environ.get('BUILDKITE_CLEAN_CHECKOUT'):
+        repo.clean()
 
 if __name__ == "__main__":
     main()

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -19,7 +19,7 @@ class P4Repo:
         view: Client workspace mapping
         stream: Client workspace stream. Overrides view parameter.
         """
-        self.root = os.path.abspath(root)
+        self.root = os.path.abspath(root or '')
         self.stream = stream
         self.view = self._localize_view(view or [])
         self.parallel = parallel

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -19,7 +19,7 @@ class P4Repo:
         view: Client workspace mapping
         stream: Client workspace stream. Overrides view parameter.
         """
-        self.root = root
+        self.root = os.path.abspath(root)
         self.stream = stream
         self.view = self._localize_view(view or [])
         self.parallel = parallel


### PR DESCRIPTION
Resolves #51 - in this case 'clean' means p4 clean, not blat the workspace and start from scratch. 

We can look at changing this meaning if it becomes genuinely useful to start from scratch - this should suffice though.