### PR TITLE
Add function to make a copy of a shelved changelist

### DIFF
--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -180,3 +180,16 @@ def test_unshelve():
         repo.sync()
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Hello World\n", "Unexpected content in workspace file"
+
+def test_backup_shelve():
+    """Test unshelving a pending changelist"""
+    setup_server(from_zip='server.zip')
+
+    with setup_server_and_client() as client_root:
+        repo = P4Repo(root=client_root)
+
+        backup_changelist = repo.backup('3')
+        assert backup_changelist != '3', "Backup changelist number must be new"
+        repo.unshelve(backup_changelist)
+        with open(os.path.join(client_root, "file.txt")) as content:
+            assert content.read() == "Goodbye World\n", "Unexpected content in workspace file"

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -190,6 +190,7 @@ def test_backup_shelve():
 
         backup_changelist = repo.backup('3')
         assert backup_changelist != '3', "Backup changelist number must be new"
+        repo.revert()
         repo.unshelve(backup_changelist)
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Goodbye World\n", "Unexpected content in workspace file"

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -183,8 +183,6 @@ def test_unshelve():
 
 def test_backup_shelve():
     """Test making a copy of a shelved changelist"""
-    setup_server(from_zip='server.zip')
-
     with setup_server_and_client() as client_root:
         repo = P4Repo(root=client_root)
 

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -182,7 +182,7 @@ def test_unshelve():
             assert content.read() == "Hello World\n", "Unexpected content in workspace file"
 
 def test_backup_shelve():
-    """Test unshelving a pending changelist"""
+    """Test making a copy of a shelved changelist"""
     setup_server(from_zip='server.zip')
 
     with setup_server_and_client() as client_root:


### PR DESCRIPTION
1. Revert open files in workspace
2. Unshelve files into default changelist
3. Make a new numbered change from files in default changelist
4. Shelve files in numbered change

You now have a copy of the shelved changelist to build against, instead of one that the user could potentially modify during the build.