### PR TITLE
Parse output of save_change more reliably/obviously

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -148,8 +148,9 @@ class P4Repo:
         # Make pending CL from default CL
         unshelved = self.perforce.fetch_change()
         unshelved._description = 'Backup of %s for precommit testing in Buildkite' % changelist
-        output = self.perforce.save_change(unshelved)
-        backup_cl = output[0].split()[1] # Change X created with Y open file(s).
+        output = self.perforce.save_change(unshelved)[0]
+        match = re.search(r'Change (\d+) created', output)
+        backup_cl = match.group(1)
         self.perforce.run_shelve('-c', backup_cl)
         return backup_cl
 


### PR DESCRIPTION
This is the only place where perforce reports which CL number it actually created, but it might include things like timestamps. Better to regex it out.