### PR TITLE
When running against #master, clean up self

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -4,4 +4,6 @@ set -euo pipefail
 python -m pip install -r "${BASH_SOURCE%/*}/../python/requirements.txt"
 python "${BASH_SOURCE%/*}/../python/checkout.py"
 
-rm -rf $(dirname ${BASH_SOURCE%/*})
+if [[ $BUILDKITE_PLUGINS == *"perforce-buildkite-plugin#master"* ]]; then
+    rm -rf $(dirname ${BASH_SOURCE%/*})
+fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -3,3 +3,5 @@ set -euo pipefail
 
 python -m pip install -r "${BASH_SOURCE%/*}/../python/requirements.txt"
 python "${BASH_SOURCE%/*}/../python/checkout.py"
+
+rm -rf $(dirname ${BASH_SOURCE%/*})


### PR DESCRIPTION
This allows faster iteration via master without having to manually delete the plugin each time - just a minor workflow improvement while I iron some things out