### PR TITLE
Enable allwrite on client workspaces

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -33,6 +33,7 @@ def get_config():
     conf['stream'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_STREAM')
     conf['sync'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SYNC')
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 0
+    conf['client_opts'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
 
     # Coerce view into pairs of [depot client] paths
     view_parts = conf['view'].split(' ')

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -13,7 +13,8 @@ from P4 import P4, P4Exception, Progress  # pylint: disable=import-error
 
 class P4Repo:
     """A class for manipulating perforce workspaces"""
-    def __init__(self, root=None, view=None, stream=None, sync=None, parallel=0):
+    def __init__(self, root=None, view=None, stream=None,
+                 sync=None, client_opts=None, parallel=0):
         """
         root: Directory in which to create the client workspace
         view: Client workspace mapping
@@ -23,6 +24,7 @@ class P4Repo:
         self.stream = stream
         self.view = self._localize_view(view or [])
         self.sync_paths = sync or '//...'
+        self.client_opts = client_opts or ''
         self.parallel = parallel
 
         self.created_client = False
@@ -75,11 +77,9 @@ class P4Repo:
         if self.view:
             client._view = self.view
 
-        # overwrite writeable-but-unopened files
+        # unless overidden, overwrite writeable-but-unopened files
         # (e.g. interrupted syncs, artefacts that have been checked-in)
-        client._options = client._options.replace('noclobber', 'clobber')
-        # fully writeable workspace
-        client._options = client._options.replace('noallwrite', 'allwrite')
+        client._options = self.client_opts + ' clobber'
 
         if not os.path.isfile(os.path.join(self.root, "p4config")):
             self.perforce.logger.warn("p4config was missing, creating a fresh workspace")

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -78,6 +78,8 @@ class P4Repo:
         # overwrite writeable-but-unopened files
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = client._options.replace('noclobber', 'clobber')
+        # fully writeable workspace
+        client._options = client._options.replace('noallwrite', 'allwrite')
 
         if not os.path.isfile(os.path.join(self.root, "p4config")):
             self.perforce.logger.warn("p4config was missing, creating a fresh workspace")


### PR DESCRIPTION
Not 100% sure about this, but it does prevent issues with build systems that assume everything is writeable. Perhaps add support for customising these options instead of enabling by default.