### PR TITLE
omit timestamp in shelved change annotation

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -12,7 +12,7 @@ __LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
 __REVISION_METADATA__ = 'buildkite:perforce:revision'
 __REVISION_ANNOTATION__ = "Revision: %s"
 __SHELVED_METADATA__ = 'buildkite:perforce:shelved'
-__SHELVED_ANNOTATION__ = "[{timestamp}] Saved shelved change {original} as {copy}"
+__SHELVED_ANNOTATION__ = "Saved shelved change {original} as {copy}"
 
 def get_env():
     """Get env vars passed in via plugin config"""
@@ -77,7 +77,6 @@ def set_build_changelist(changelist):
         subprocess.call([
             'buildkite-agent', 'annotate', 
             __SHELVED_ANNOTATION__.format(**{
-                'timestamp': datetime.now().strftime("%m/%d/%Y %H:%M:%S"),
                 'original': get_users_changelist(),
                 'copy': changelist,
             }),


### PR DESCRIPTION
we dont really care what time this happened, the info is visible in the form of when steps ran anyway