### PR TITLE
Set build description and revision

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -10,7 +10,6 @@ __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
 __LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
 
 __REVISION_METADATA__ = 'buildkite:perforce:revision'
-__REVISION_ANNOTATION__ = "Revision: %s"
 __SHELVED_METADATA__ = 'buildkite:perforce:shelved'
 __SHELVED_ANNOTATION__ = "Saved shelved change {original} as {copy}"
 

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -93,8 +93,7 @@ def get_build_revision():
 
 def set_build_revision(revision):
     """Set the p4 revision for following jobs in this build"""
-    if set_metadata(__REVISION_METADATA__, revision):
-        subprocess.call(['buildkite-agent', 'annotate', __REVISION_ANNOTATION__ % revision, '--context', __REVISION_METADATA__, '--style', 'info'])
+    set_metadata(__REVISION_METADATA__, revision)
 
 def set_build_info(revision, description):
     """Set the description and commit number in the UI for this build by mimicking a git repo"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -80,7 +80,8 @@ def set_build_changelist(changelist):
                 'original': get_users_changelist(),
                 'copy': changelist,
             }),
-            '--context', __SHELVED_METADATA__
+            '--context', __SHELVED_METADATA__,
+            '--style', 'info',
         ])
 
 def get_build_revision():
@@ -93,7 +94,7 @@ def get_build_revision():
 def set_build_revision(revision):
     """Set the p4 revision for following jobs in this build"""
     if set_metadata(__REVISION_METADATA__, revision):
-        subprocess.call(['buildkite-agent', 'annotate', __REVISION_ANNOTATION__ % revision, '--context', __REVISION_METADATA__])
+        subprocess.call(['buildkite-agent', 'annotate', __REVISION_ANNOTATION__ % revision, '--context', __REVISION_METADATA__, '--style', 'info'])
 
 def set_build_info(revision, description):
     """Set the description and commit number in the UI for this build by mimicking a git repo"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -94,3 +94,7 @@ def set_build_revision(revision):
     """Set the p4 revision for following jobs in this build"""
     if set_metadata(__REVISION_METADATA__, revision):
         subprocess.call(['buildkite-agent', 'annotate', __REVISION_ANNOTATION__ % revision, '--context', __REVISION_METADATA__])
+
+def set_build_info(revision, description):
+    """Set the description and commit number in the UI for this build by mimicking a git repo"""
+    set_metadata('buildkite:git:commit', 'commit %s\n\n\t%s' % (revision, description))

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -7,7 +7,7 @@ import subprocess
 
 from perforce import P4Repo
 from buildkite import (get_env, get_config, get_build_revision, set_build_revision,
-    get_users_changelist, get_build_changelist, set_build_changelist)
+    get_users_changelist, get_build_changelist, set_build_changelist, set_build_info)
 
 def main():
     """Main"""
@@ -19,7 +19,8 @@ def main():
     revision = get_build_revision()
     if revision == 'HEAD':
         # Resolve HEAD to a concrete revision
-        revision = repo.head()
+        head = repo.head()
+        revision = '@%s' % head
         set_build_revision(revision)
 
     repo.sync(revision=revision)
@@ -36,6 +37,9 @@ def main():
             set_build_changelist(changelist)
 
         repo.unshelve(changelist)
+
+    description = repo.description(get_build_changelist() or head)
+    set_build_info(head, description)
 
 
 if __name__ == "__main__":

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -38,7 +38,7 @@ def main():
 
         repo.unshelve(changelist)
 
-    description = repo.description(get_build_changelist() or head)
+    description = repo.description(get_users_changelist() or head)
     set_build_info(head, description)
 
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -127,7 +127,11 @@ class P4Repo:
 
     def head(self):
         """Get current head revision"""
-        return '@%s' % self.perforce.run_counter("maxCommitChange")[0]['value']
+        return self.perforce.run_counter("maxCommitChange")[0]['value']
+
+    def description(self, changelist):
+        """Get description of a given changelist"""
+        return self.perforce.run_describe(str(changelist))[0]['desc']
 
     def sync(self, revision=None):
         """Sync the workspace"""

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -92,7 +92,7 @@ def test_fixture(capsys):
     # Returns [metadata, contents]
     content = repo.perforce.run_print("//depot/file.txt")[1]
     assert content == "Hello World\n"
-    assert repo.head() == "@2", "Unexpected head revision"
+    assert repo.head() == "2", "Unexpected head revision"
 
     shelved_change = repo.perforce.run_describe('-sS', '3')
     assert len(shelved_change) > 0, "Shelved changelist was missing"


### PR DESCRIPTION
* send revision and description in git-style format so the UI updates
* this means we can remove the existing annotatation
* also update the other annotation to be 'info' so it is less grey