### PR TITLE
Flush to zero instead of deleting clients

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -83,18 +83,13 @@ class P4Repo:
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_opts + ' clobber'
 
-        if not os.path.isfile(os.path.join(self.root, "p4config")):
-            self.perforce.logger.warn("p4config was missing, creating a fresh workspace")
-            try:
-                self.perforce.delete_client(clientname)
-            except P4Exception as exc:
-                # Suppress 'Client doesn't exist' messages
-                if not "doesn't exist" in str(exc):
-                    raise
-
         self.perforce.save_client(client)
-
         self.perforce.client = clientname
+
+        if not os.path.isfile(os.path.join(self.root, "p4config")):
+            self.perforce.logger.warn("p4config missing, flushing workspace to revision zero")
+            self.perforce.run_flush(['//...@0'])
+
         self._write_p4config()
         self.created_client = True
 

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -153,7 +153,7 @@ def test_workspace_recovery():
         os.remove(os.path.join(client_root, "file.txt"))
         os.remove(os.path.join(client_root, "p4config"))
         repo = P4Repo(root=client_root) # Open a fresh client, as if this was a different job
-        repo.sync() # Normally: "You already have file.txt", but since p4config is missing will re-create workspace
+        repo.sync() # Normally: "You already have file.txt", but since p4config is missing it will restore the workspace
         assert os.listdir(client_root) == [
             "file.txt", "p4config"], "Failed to restore corrupt workspace due to missing p4config"
 


### PR DESCRIPTION
* Fixes a bug where:
1. A worker runs a pre-submit build, making a copy of a shelved change (which it owns)
2. Someone runs a CLEAN build, which deletes the directory the client is synced to
3. Following build detects that p4config is missing and tries to delete the client so that it can re-create it and sync from scratch
4. Fails because deleting a client workspace that owns shelved changelists requires admin permissions + special flags
5. We don't want to do this as it could cause shelved files to be deleted while they are still require

Solution:
Instead of deleting the client, flush it to zero. That hostname+agent-number+pipeline combination is the rightful owner of the client, so this should never be disruptive