### PR TITLE
set p4config in env hook

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,0 +1,2 @@
+# Allow steps to pick up perforce configuration used by the plugin
+export P4CONFIG=p4config


### PR DESCRIPTION
* Allows the user to just run 'p4 info' and it will work, since we write out p4user, p4client and p4port to a p4config file in the rootdir