### PR TITLE
Allow switching off shelve cl backups via plugin config

### DIFF
--- a/.buildkite/local-pipeline.yml
+++ b/.buildkite/local-pipeline.yml
@@ -10,3 +10,4 @@ steps:
           view: //depot/... ...
           root: p4_workspace
           parallel: 2
+          backup_changelists: yes

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,4 +22,6 @@ configuration:
     parallel:
       type: string
     client_opts:
-      type: string      
+      type: string
+    backup_changelists:
+      type: bool

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -42,7 +42,7 @@ def get_config():
     return conf
 
 def should_backup_changelists():
-    return os.environ.get('BUILDKITE_PLUGIN_PERFORCE_BACKUP_CHANGELISTS', 'true') == 'true'
+    return os.environ.get('BUILDKITE_PLUGIN_PERFORCE_BACKUP_CHANGELISTS', 'false') == 'true'
 
 def get_metadata(key):
     """If it exists, retrieve metadata from buildkite for a given key"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -41,6 +41,9 @@ def get_config():
     conf['view'] = ['%s %s' % (v, next(view_iter)) for v in view_iter]
     return conf
 
+def should_backup_changelists():
+    return os.environ.get('BUILDKITE_PLUGIN_PERFORCE_BACKUP_CHANGELISTS', 'true') == 'true'
+
 def get_metadata(key):
     """If it exists, retrieve metadata from buildkite for a given key"""
     if not __ACCESS_TOKEN__ or __LOCAL_RUN__:

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -38,7 +38,7 @@ def main():
         # Use existing or make a copy of the users changelist for this build
         changelist = get_build_changelist()
         if not changelist:
-            if  should_backup_changelists():
+            if should_backup_changelists():
                 changelist = repo.backup(user_changelist)
             set_build_changelist(changelist)
 

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -8,7 +8,8 @@ import re
 
 from perforce import P4Repo
 from buildkite import (get_env, get_config, get_build_revision, set_build_revision,
-    get_users_changelist, get_build_changelist, set_build_changelist, set_build_info)
+    get_users_changelist, get_build_changelist, set_build_changelist, set_build_info,
+    should_backup_changelists)
 
 def main():
     """Main"""
@@ -25,7 +26,7 @@ def main():
 
     # Convert changelist number to revision specifier
     if re.match(r'^\d*$', revision):
-        revision = '@%d' % revision
+        revision = '@%s' % revision
 
     repo.sync(revision=revision)
 
@@ -33,7 +34,7 @@ def main():
         repo.clean()
 
     user_changelist = get_users_changelist()
-    if user_changelist:
+    if user_changelist and should_backup_changelists():
         # Use existing or make a copy of the users changelist for this build
         changelist = get_build_changelist()
         if not changelist:

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -34,11 +34,12 @@ def main():
         repo.clean()
 
     user_changelist = get_users_changelist()
-    if user_changelist and should_backup_changelists():
+    if user_changelist:
         # Use existing or make a copy of the users changelist for this build
         changelist = get_build_changelist()
         if not changelist:
-            changelist = repo.backup(user_changelist)
+            if  should_backup_changelists():
+                changelist = repo.backup(user_changelist)
             set_build_changelist(changelist)
 
         repo.unshelve(changelist)

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -38,6 +38,7 @@ def main():
         # Use existing or make a copy of the users changelist for this build
         changelist = get_build_changelist()
         if not changelist:
+            changelist = user_changelist
             if should_backup_changelists():
                 changelist = repo.backup(user_changelist)
             set_build_changelist(changelist)


### PR DESCRIPTION
* also fix string formatting bug
* affords more control to for e.g. builds kicked via swarm, where creating more shelved changes would be redundant