### PR TITLE
Don't run `p4 clean` as part of BUILDKITE_CLEAN_CHECKOUT=true

### DIFF
--- a/python/checkout.py
+++ b/python/checkout.py
@@ -30,9 +30,6 @@ def main():
 
     repo.sync(revision=revision)
 
-    if os.environ.get('BUILDKITE_CLEAN_CHECKOUT'):
-        repo.clean()
-
     user_changelist = get_users_changelist()
     if user_changelist:
         # Use existing or make a copy of the users changelist for this build


### PR DESCRIPTION
Clean checkouts remove the entire directory, so running p4 clean afterwards is redundant and just wastes time
