### PR TITLE
Throw exception when 'root' plugin setting is used by people

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -11,8 +11,6 @@ configuration:
       type: string
     p4trust:
       type: string  
-    root:
-      type: string
     view:
       type: string
     stream:

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -27,12 +27,16 @@ def get_env():
 def get_config():
     """Get configuration which will be passed directly to perforce.P4Repo as kwargs"""
     conf = {}
-    conf['root'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_ROOT') or os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH')
     conf['view'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_VIEW') or '//... ...'
     conf['stream'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_STREAM')
     conf['sync'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SYNC')
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 0
     conf['client_opts'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
+
+    if 'BUILDKITE_PLUGIN_PERFORCE_ROOT' in os.environ and not __LOCAL_RUN__:
+        raise Exception("Custom P4 root is for use in unit tests only")
+    conf['root'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_ROOT') or os.environ.get('BUILDKITE_BUILD_CHECKOUT_PATH')
+
 
     # Coerce view into pairs of [depot client] paths
     view_parts = conf['view'].split(' ')


### PR DESCRIPTION
This is just supposed to be for unit/integration tests to make cleaning up etc more straight forward