### PR TITLE
Add 'stream sharing' feature, allowing avoidance of multiple syncs

### DIFF
--- a/.buildkite/local-pipeline.yml
+++ b/.buildkite/local-pipeline.yml
@@ -12,11 +12,11 @@ steps:
           parallel: 2
           backup_changelists: yes
 
-  - label: "Test Shared Streams"
-    command: echo "Hello World"
-    plugins:
-      - ./.buildkite/plugins/perforce:
-          p4port: localhost:1666
-          p4user: banana
-          stream: //stream-depot/main # will checkout to ../__stream_depot_main
-          share_workspace: yes
+  # - label: "Test Shared Streams"
+  #   command: echo "Hello World"
+  #   plugins:
+  #     - ./.buildkite/plugins/perforce:
+  #         p4port: localhost:1666
+  #         p4user: banana
+  #         stream: //stream-depot/main # will checkout to ../__stream_depot_main
+  #         share_workspace: yes

--- a/.buildkite/local-pipeline.yml
+++ b/.buildkite/local-pipeline.yml
@@ -11,3 +11,12 @@ steps:
           root: p4_workspace
           parallel: 2
           backup_changelists: yes
+
+  - label: "Test Shared Streams"
+    command: echo "Hello World"
+    plugins:
+      - ./.buildkite/plugins/perforce:
+          p4port: localhost:1666
+          p4user: banana
+          stream: //stream-depot/main # will checkout to ../__stream_depot_main
+          share_workspace: yes

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ steps:
           parallel: 16
 ```
 
+Share a stream workspace between pipelines. Useful to avoid syncing duplicate data with large workspaces.
+Only allowed when there is a single buildkite agent running on the machine.
+
+```yaml
+steps:
+    plugins:
+      - ca-johnson/perforce:
+          stream: //dev/buildkite
+          share_workspace: true
+```
+
 ## Triggering Builds
 
 There are a few options for triggering builds that use this plugin, in this order from least valuable but most convenient to most valueable but least convenient.

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,7 +2,7 @@
 export P4CONFIG=p4config
 
 # Allow sharing of perforce client workspaces for the same stream between pipelines
-if "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" ; then
+if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]] ; then
     echo "Workspace sharing enabled"
 
     STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,2 +1,19 @@
 # Allow steps to pick up perforce configuration used by the plugin
 export P4CONFIG=p4config
+
+# Allow sharing of perforce client workspaces for the same stream between pipelines
+if "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" ; then
+    echo "Workspace sharing enabled"
+
+    STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"
+    if [[ -z "${STREAM}" ]] ; then
+      echo "ERROR: You must use stream workspaces to enable shared workspaces" >&2
+      exit 1
+    fi
+    # Sanitize //depot/stream-name to __depot_stream-name
+    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
+
+    PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../${SANITIZED_STREAM}"
+    export BUILDKITE_BUILD_CHECKOUT_PATH="${PERFORCE_CHECKOUT_PATH}"
+    echo "Changed BUILDKITE_BUILD_CHECKOUT_PATH to ${PERFORCE_CHECKOUT_PATH}"
+fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -7,7 +7,11 @@ if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]] ; then
 
     STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"
     if [[ -z "${STREAM}" ]] ; then
-      echo "ERROR: You must use stream workspaces to enable shared workspaces" >&2
+      echo "Error: You must use stream workspaces to enable shared workspaces" >&2
+      exit 1
+    fi
+    if [[ "${BUILDKITE_AGENT_META_DATA_AGENT_COUNT}" -gt 1 ]] ; then
+      echo "Error: You cannot share stream workspaces when running more than one agent" >&2
       exit 1
     fi
     # Sanitize //depot/stream-name to __depot_stream-name

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -50,7 +50,8 @@ class P4Repo:
         self.perforce.disconnect()
 
     def _get_clientname(self):
-        clientname = 'bk-p4-%s-%s' % (os.environ.get('BUILDKITE_AGENT_NAME', socket.gethostname()), os.environ.get('BUILDKITE_PIPELINE_SLUG', ''))
+        """Get unique clientname for this host and location on disk"""
+        clientname = 'bk-p4-%s-%s' % (os.environ.get('BUILDKITE_AGENT_NAME', socket.gethostname()), os.path.basename(self.root))
         return re.sub(r'\W', '-', clientname)
 
     def _localize_view(self, view):


### PR DESCRIPTION
* Multiple pipelines may sync the same perforce stream
* Normally, each pipeline gets a separate directory
* Instead, sync perforce into a unique directory per-stream and CD to that as the build directory