### PR TITLE
Allow client data to be re-used on a different host

### DIFF
--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -192,7 +192,7 @@ def test_backup_shelve():
             assert content.read() == "Goodbye World\n", "Unexpected content in workspace file"
 
 def test_client_migration():
-    """Test re-use of workspace data when client moves to another host"""
+    """Test re-use of workspace data when moved to another host"""
     with setup_server_and_client() as client_root:
         repo = P4Repo(root=client_root)
 
@@ -203,5 +203,5 @@ def test_client_migration():
         with tempfile.TemporaryDirectory(prefix="bk-p4-test-") as second_client_root:
             copy_tree(client_root, second_client_root)
             repo = P4Repo(root=second_client_root)
-            synced = repo.sync()
+            synced = repo.sync() # Flushes to match previous client, since p4config is there on disk
             assert synced == [], "Should not have synced any files in second client"

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -12,7 +12,6 @@ import tempfile
 import time
 import zipfile
 import pytest
-from distutils.dir_util import copy_tree
 
 from perforce import P4Repo
 
@@ -191,6 +190,17 @@ def test_backup_shelve():
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Goodbye World\n", "Unexpected content in workspace file"
 
+
+def copytree(src, dst):
+    """Shim to get around shutil.copytree requiring root dir to not exist"""
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d)
+        else:
+            shutil.copy2(s, d)
+
 def test_client_migration():
     """Test re-use of workspace data when moved to another host"""
     with setup_server_and_client() as client_root:
@@ -201,7 +211,7 @@ def test_client_migration():
         assert len(synced) > 0, "Didn't sync any files"
 
         with tempfile.TemporaryDirectory(prefix="bk-p4-test-") as second_client_root:
-            copy_tree(client_root, second_client_root)
+            copytree(client_root, second_client_root)
             repo = P4Repo(root=second_client_root)
             synced = repo.sync() # Flushes to match previous client, since p4config is there on disk
             assert synced == [], "Should not have synced any files in second client"

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 import zipfile
 import pytest
+from distutils.dir_util import copy_tree
 
 from perforce import P4Repo
 
@@ -189,3 +190,18 @@ def test_backup_shelve():
         repo.unshelve(backup_changelist)
         with open(os.path.join(client_root, "file.txt")) as content:
             assert content.read() == "Goodbye World\n", "Unexpected content in workspace file"
+
+def test_client_migration():
+    """Test re-use of workspace data when client moves to another host"""
+    with setup_server_and_client() as client_root:
+        repo = P4Repo(root=client_root)
+
+        assert os.listdir(client_root) == [], "Workspace should be empty"
+        synced = repo.sync()
+        assert len(synced) > 0, "Didn't sync any files"
+
+        with tempfile.TemporaryDirectory(prefix="bk-p4-test-") as second_client_root:
+            copy_tree(client_root, second_client_root)
+            repo = P4Repo(root=second_client_root)
+            synced = repo.sync()
+            assert synced == [], "Should not have synced any files in second client"


### PR DESCRIPTION
Addresses #108 

Allows re-use of data disks by fresh instances
Allows baking a perforce sync into instance images

Caveat:
* If the host that we are cloning this workspace from is still running, this gets broken.

As it stands, this should *never* be the case since we either:
* Are spinning up an agent temporarily and 'blessing' the resulting image, then shutting it down
or
* The old agent is permanently dead and we are re-using its data disk