### PR TITLE
Switch to p4print unshelve as default method

### DIFF
--- a/python/checkout.py
+++ b/python/checkout.py
@@ -40,7 +40,7 @@ def main():
                 changelist = repo.backup(user_changelist)
             set_build_changelist(changelist)
 
-        repo.unshelve(changelist)
+        repo.p4print_unshelve(changelist)
 
     revision = get_build_revision()
     description = repo.description(get_users_changelist() or revision.strip('@'))


### PR DESCRIPTION
* Instead of actually unshelving files and checking them out, p4print contents into the local file directly
* Follow up to #112, addresses #102 in full
* 'Unshelved' files are reverted afterwards using p4 clean
* Avoids clutter in p4v where build agents have files checked out