### PR TITLE
Stream Sharing: modify build directory for all following stages in the step

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -1,26 +1,5 @@
 #!/bin/bash
 set -eo pipefail
 
-# Allow sharing of perforce client workspaces for the same stream between pipelines
-if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]] ; then
-    echo "Workspace sharing enabled"
-
-    STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"
-    if [[ -z "${STREAM}" ]] ; then
-      echo "Error: You must use stream workspaces to enable shared workspaces" >&2
-      exit 1
-    fi
-    if [[ "${BUILDKITE_AGENT_META_DATA_AGENT_COUNT}" -gt 1 ]] ; then
-      echo "Error: You cannot share stream workspaces when running more than one agent" >&2
-      exit 1
-    fi
-    # Sanitize //depot/stream-name to __depot_stream-name
-    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
-
-    PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../${SANITIZED_STREAM}"
-    export BUILDKITE_BUILD_CHECKOUT_PATH="${PERFORCE_CHECKOUT_PATH}"
-    echo "Changed BUILDKITE_BUILD_CHECKOUT_PATH to ${PERFORCE_CHECKOUT_PATH}"
-fi
-
 python -m pip install -r "${BASH_SOURCE%/*}/../python/requirements.txt"
 python "${BASH_SOURCE%/*}/../python/checkout.py"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eo pipefail
+
+# Allow sharing of perforce client workspaces for the same stream between pipelines
+if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]] ; then
+    echo "Workspace sharing enabled"
+
+    STREAM="${BUILDKITE_PLUGIN_PERFORCE_STREAM}"
+    if [[ -z "${STREAM}" ]] ; then
+      echo "Error: You must use stream workspaces to enable shared workspaces" >&2
+      exit 1
+    fi
+    if [[ "${BUILDKITE_AGENT_META_DATA_AGENT_COUNT}" -gt 1 ]] ; then
+      echo "Error: You cannot share stream workspaces when running more than one agent" >&2
+      exit 1
+    fi
+    # Sanitize //depot/stream-name to __depot_stream-name
+    SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
+
+    PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../${SANITIZED_STREAM}"
+    export BUILDKITE_BUILD_CHECKOUT_PATH="${PERFORCE_CHECKOUT_PATH}"
+    echo "Changed BUILDKITE_BUILD_CHECKOUT_PATH to ${PERFORCE_CHECKOUT_PATH}"
+fi


### PR DESCRIPTION
Modifying it in the checkout hook doesn't allow other plugins and the command step to occurr in the correct working directory, instead modify it in a new pre-checkout hook.


from https://buildkite.com/docs/pipelines/environment-variables
BUILDKITE_BUILD_CHECKOUT_PATH
The path where the agent has checked out your code for this build. This variable is read by the bootstrap when the agent is started, and can only be set by exporting the environment variable in the environment or pre-checkout hooks.

Example: "/var/lib/buildkite-agent/builds/agent-1/pipeline-2"