### PR TITLE
Consistent venv location

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -10,7 +10,7 @@ else
     venv_module="venv"
 fi
 
-venv_dir="${PWD}/../.perforce-plugin-venv"
+venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv"
 
 python -m pip install "${venv_module}"
 python -m "${venv_module}" "${venv_dir}"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,7 +3,7 @@ set -euo pipefail
 
 plugin_root="${BASH_SOURCE%/*}/.."
 
-venv_dir="${PWD}/../.perforce-plugin-venv"
+venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv"
 
 platform=$(python -c "import platform; print(platform.system())")
 if [[ "${platform}" == "Windows" ]]; then


### PR DESCRIPTION
Only env and checkout hooks can change BUILDKITE_BUILD_CHECKOUT_PATH, so this is likely to be the same path in both checkout and pre-exit. More so than PWD