### PR TITLE
Unmapped files do not cause an exception

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -215,10 +215,11 @@ class P4Repo:
         printinfo = self.perforce.run_print(shelved_depotfiles)
 
         # coerce [info, content, info, content]
-        # into {depotpath: content, depotpath: content}
+        # into {localpath: content, localpath: content}
         local_to_content = {depot_to_local[fileinfo['depotFile']]: (fileinfo, content)
                             for fileinfo, content in
-                            zip(printinfo[0::2], printinfo[1::2])}
+                            zip(printinfo[0::2], printinfo[1::2])
+                            if fileinfo['depotFile'] in depot_to_local}
 
         # Flag these files as modified
         self._write_patched(list(local_to_content.keys()))

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -207,6 +207,11 @@ def test_p4print_unshelve():
             assert content.read() == "Hello World\n", "Unexpected content in workspace file"
         assert not os.path.exists(os.path.join(client_root, "newfile.txt"))
 
+        # Shelved changes containing files not mapped into this workspace do not throw an exception
+        repo = P4Repo(root=client_root, stream='//stream-depot/main')
+        repo.p4print_unshelve('3') # Modify a file
+
+
 
 def test_backup_shelve():
     """Test making a copy of a shelved changelist"""

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -211,8 +211,6 @@ def test_p4print_unshelve():
         repo = P4Repo(root=client_root, stream='//stream-depot/main')
         repo.p4print_unshelve('3') # Modify a file
 
-
-
 def test_backup_shelve():
     """Test making a copy of a shelved changelist"""
     with setup_server_and_client() as client_root:


### PR DESCRIPTION
When trying to p4print_unshelve a changelist which happens to contain files not mapped into the build agents workspace, instead of throwing an error it is simply ignored.