### PR TITLE
Fix unit tests vs new p4api minor version release

### DIFF
--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -6,7 +6,9 @@ wget http://www.perforce.com/downloads/perforce/r18.2/bin.linux26x86_64/p4d && s
 
 # Build P4Python from source, pip install fails as we cannot connect to ftp.perforce.com from travis agents
 wget http://www.perforce.com/downloads/perforce/r18.2/bin.linux26x86_64/p4api.tgz
+# Detect concrete version number inside p4api.tgz
+local P4API_VERSION=$(tar -tf p4api.tgz | head -1)
 tar xzf p4api.tgz --directory /tmp/
 wget https://files.pythonhosted.org/packages/36/5a/0a1b192cdecd31cb8bc0d0ba39c73ffd84ce823053d0004823a1fdbe1440/p4python-2018.2.1743033.tar.gz
 tar xfz p4python-2018.2.1743033.tar.gz --directory /tmp/
-pushd /tmp/p4python-2018.2.1743033/ && python setup.py install --apidir /tmp/p4api-2018.2.1850148 && popd
+pushd /tmp/p4python-2018.2.1743033/ && python setup.py install --apidir /tmp/${P4API_VERSION} && popd

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -7,7 +7,7 @@ wget http://www.perforce.com/downloads/perforce/r18.2/bin.linux26x86_64/p4d && s
 # Build P4Python from source, pip install fails as we cannot connect to ftp.perforce.com from travis agents
 wget http://www.perforce.com/downloads/perforce/r18.2/bin.linux26x86_64/p4api.tgz
 # Detect concrete version number inside p4api.tgz
-local P4API_VERSION=$(tar -tf p4api.tgz | head -1)
+P4API_VERSION=$(tar -tf p4api.tgz | head -1)
 tar xzf p4api.tgz --directory /tmp/
 wget https://files.pythonhosted.org/packages/36/5a/0a1b192cdecd31cb8bc0d0ba39c73ffd84ce823053d0004823a1fdbe1440/p4python-2018.2.1743033.tar.gz
 tar xfz p4python-2018.2.1743033.tar.gz --directory /tmp/


### PR DESCRIPTION
The directory inside p4api.tgz changes its name with each version release

We must supply this directory name to setup.py to build p4python from source

Instead of hard-coding the version, autodetect it.