### PR TITLE
HEAD is resolved vs buildmachines client view

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -148,11 +148,12 @@ class P4Repo:
 
     def head(self):
         """Get current head revision"""
-        if self.stream is not None:
-            stream_head = self.perforce.run_changes([
-                '-m', '1', '-s', 'submitted', '%s/...' % self.stream])
-            if stream_head:
-                return stream_head[0]['change']
+        self._setup_client()
+        client_head = self.perforce.run_changes([
+            '-m', '1', '-s', 'submitted', '//%s/...' % self._get_clientname()])
+        if client_head:
+            return client_head[0]['change']
+        # Fallback for when client view has no submitted changes
         return self.perforce.run_counter("maxCommitChange")[0]['value']
 
     def description(self, changelist):

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -104,14 +104,16 @@ def test_fixture(capsys):
 def test_head():
     """Test resolve of HEAD changelist"""
     setup_server(from_zip='server.zip')
-    repo = P4Repo(stream='//stream-depot/main')
-    assert repo.head() == "2", "Unexpected HEAD revision for stream"
 
     repo = P4Repo()
     assert repo.head() == "6", "Unexpected global HEAD revision"
 
+    repo = P4Repo(stream='//stream-depot/main')
+    assert repo.head() == "2", "Unexpected HEAD revision for stream"
+
     repo = P4Repo(stream='//stream-depot/idontexist')
-    assert repo.head() == "6", "Non-existent stream should fallback to global HEAD revision"
+    with pytest.raises(Exception, match=r"Stream '//stream-depot/idontexist' doesn't exist."):
+        repo.head()
 
 def test_checkout():
     """Test normal flow of checking out files"""


### PR DESCRIPTION
Seems like a more predictable and reliable way to detect HEAD, avoiding confusion on scheduled builds when maxCommitChange is given as HEAD which may be a changelist outside your concern.

Avoids errors vs virtual streams