### PR TITLE
Allow using plugin in mixed perforce/git pipelines

### DIFF
--- a/python/checkout.py
+++ b/python/checkout.py
@@ -19,8 +19,8 @@ def main():
     repo = P4Repo(**config)
 
     revision = get_build_revision()
-    if revision == 'HEAD':
-        # Resolve HEAD to a concrete revision
+    if not revision.isdigit():
+        # Resolve 'HEAD' or ignore git sha and find a concrete revision
         revision = repo.head()
         set_build_revision(revision)
 


### PR DESCRIPTION
* this permits for e.g. to have a pipeline which lives in git, but actually syncs perforce at current head revision
* avoids trying to sync `//...@git-sha`