### PR TITLE
Prefer explicit python3 if installed

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -5,10 +5,16 @@ plugin_root="${BASH_SOURCE%/*}/.."
 
 venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv"
 
-python -m pip install virtualenv==16.7.7
-python -m virtualenv "${venv_dir}"
+# Try to use explicit python3 if its installed
+python_bin="python3"
+if ! command -v ${python_bin} >/dev/null 2>&1 then
+    python_bin="python"
+fi
 
-platform=$(python -c "import platform; print(platform.system())")
+${python_bin} -m pip install virtualenv==16.7.7
+${python_bin} -m virtualenv "${venv_dir}"
+
+platform=$(${python_bin} -c "import platform; print(platform.system())")
 if [[ "${platform}" == "Windows" ]]; then
     venv_bin="${venv_dir}/Scripts"
 else

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -7,7 +7,7 @@ venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv"
 
 # Try to use explicit python3 if its installed
 python_bin="python3"
-if ! command -v ${python_bin} >/dev/null 2>&1 then
+if ! [[ -x "$(command -v ${python_bin})" ]]; then
     python_bin="python"
 fi
 


### PR DESCRIPTION
Create the virtualenv using python3 if possible, otherwise fallback to `python` (which could still be python3)

* retains backwards compatability but prefers py3

testing strategy:
* python3 actively used in Windows builds
* installed python2 and python3 on Unix machine, it picked up py3 instead of using `python` which was still symlinked to py2