### PR TITLE
Reduce amount of log spam when syncing large depots

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -262,10 +262,17 @@ class SyncOutput(OutputHandler):
     def __init__(self, logger):
         OutputHandler.__init__(self)
         self.logger = logger
+        self.sync_count = 0
     
     def outputStat(self, stat):
         if 'depotFile' in stat:
-            self.logger.info("%(depotFile)s#%(rev)s %(action)s" % stat)
+            self.sync_count  += 1
+            if self.sync_count < 1000:
+                # Normal, verbose logging of synced file
+                self.logger.info("%(depotFile)s#%(rev)s %(action)s" % stat)
+            elif self.sync_count % 1000 == 0:
+                # Syncing many files, print one message for every 1000 files to reduce log spam
+                self.logger.info("Synced %d files..." % self.sync_count)
         return OutputHandler.REPORT
 
 


### PR DESCRIPTION
* In builds which do a clean sync, this can produce over 100k lines of log output
* This causes buildkite to truncate our logs, making them more difficult to navigate
* We are getting 'buffer full' warnings when sending stuff to logstash interleaved with this output which doubles up the amount of log spam
* These messages provide very little value beyond the first 1000 or so (i.e. is it actually syncing the depot I asked for), so theres no real need to have hundreds of thousands of lines like this
* Dealing with all of this output is potentially causing some performance regression during the sync