### PR TITLE
Share stream checkout between all agents

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -17,7 +17,8 @@ if [[ "${BUILDKITE_PLUGIN_PERFORCE_SHARE_WORKSPACE}" == true ]] ; then
     # Sanitize //depot/stream-name to __depot_stream-name
     SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
 
-    PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../${SANITIZED_STREAM}"
+    # Instead of builds/<agent_number>/<pipeline>, checkout to builds/<stream_name>
+    PERFORCE_CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}/../../${SANITIZED_STREAM}"
     export BUILDKITE_BUILD_CHECKOUT_PATH="${PERFORCE_CHECKOUT_PATH}"
     echo "Changed BUILDKITE_BUILD_CHECKOUT_PATH to ${PERFORCE_CHECKOUT_PATH}"
 fi


### PR DESCRIPTION
The `share_workspace` feature allows you to avoid checking out a depot for every pipeline

This change allows you to avoid checking it out for every pipeline *and* every agent

* Addresses an issue where if buildkite-agent process is restarted, it can connect as agent `2` for that hostname, even though `AGENT_COUNT=1`
* This would break the sharing of workspace, since it lives inside `builds/1/__stream_name`
* This change moves the build to `builds/__stream_name`, so they are not agent-number specific
* Note that this feature is already restricted to AGENT_COUNT=1 (see line 14)