### PR TITLE
Avoid pip install of virtualenv module if possible

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -13,7 +13,7 @@ fi
 
 # Ensure some version of virtualenv is installed
 # Lazy install avoids races between different jobs wanting different versions
-if [[ $(${python_bin} -m pip freeze) =~ "virtualenv==" ]]; then
+if [[ ! $(${python_bin} -m pip freeze) =~ "virtualenv==" ]]; then
     ${python_bin} -m pip install "virtualenv==16.7.7"
 fi
 ${python_bin} -m virtualenv "${venv_dir}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -11,7 +11,8 @@ if ! [[ -x "$(command -v ${python_bin})" ]]; then
     python_bin="python"
 fi
 
-# We aren't particularly precious over the version of virtualenv, just that its installed
+# Ensure some version of virtualenv is installed
+# Lazy install avoids races between different jobs wanting different versions
 if [[ $(${python_bin} -m pip freeze) =~ "virtualenv=" ]]; then
     ${python_bin} -m pip install "virtualenv==16.7.7"
 fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -13,7 +13,7 @@ fi
 
 # Ensure some version of virtualenv is installed
 # Lazy install avoids races between different jobs wanting different versions
-if [[ $(${python_bin} -m pip freeze) =~ "virtualenv=" ]]; then
+if [[ $(${python_bin} -m pip freeze) =~ "virtualenv==" ]]; then
     ${python_bin} -m pip install "virtualenv==16.7.7"
 fi
 ${python_bin} -m virtualenv "${venv_dir}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -11,7 +11,10 @@ if ! [[ -x "$(command -v ${python_bin})" ]]; then
     python_bin="python"
 fi
 
-${python_bin} -m pip install virtualenv==16.7.7
+# We aren't particularly precious over the version of virtualenv, just that its installed
+if [[ $(${python_bin} -m pip freeze) =~ "virtualenv=" ]]; then
+    ${python_bin} -m pip install "virtualenv==16.7.7"
+fi
 ${python_bin} -m virtualenv "${venv_dir}"
 
 platform=$(${python_bin} -c "import platform; print(platform.system())")


### PR DESCRIPTION
* We don't really care about the version of virtualenv, just that its installed
* Allows for compatibility with infra that doesn't permit `pip install` by requiring them to install virtualenv already
* Using `=~` instead of `grep` for compatibility
* Resolves internal issue ENG-2806