### PR TITLE
Rename metadata to be compatible with bk local run

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -10,8 +10,8 @@ __ACCESS_TOKEN__ = os.environ['BUILDKITE_AGENT_ACCESS_TOKEN']
 # https://github.com/buildkite/cli/blob/e8aac4bedf34cd8084a3ae7a4ab7812c611d0310/local/run.go#L403
 __LOCAL_RUN__ = os.environ['BUILDKITE_AGENT_NAME'] == 'local'
 
-__REVISION_METADATA__ = 'buildkite:perforce:revision'
-__SHELVED_METADATA__ = 'buildkite:perforce:shelved'
+__REVISION_METADATA__ = 'buildkite-perforce-revision'
+__SHELVED_METADATA__ = 'buildkite-perforce-shelved'
 __SHELVED_ANNOTATION__ = "Saved shelved change {original} as {copy}"
 
 def get_env():


### PR DESCRIPTION
* Requires major version release - breaks compatibility if anyone is explicitly setting this metadata to override synced changelists
* They should not really be doing this, fwiw as this is an internal implementation detail

When running `bk local run` in integration tests, we must specific metadata via `--meta-data`
The bk cli uses kingpin.v2 to parse these args, and it splits on `[:=]`
This means an arg like `--meta-data perforce:revision=6` is coerced to: `"perforce": "revision=6:"`, which is incorrect. There is no way to escape this (see https://github.com/alecthomas/kingpin/blob/v2.2.6/values.go#L142)
Instead, switch to using `-`
