### PR TITLE
Fix makefile integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 local_run: vendorize p4d
 	rm -f -r p4_workspace
 	mkdir local-pipeline -p
-	pushd local-pipeline && bk local run ../.buildkite/local-pipeline.yml
+	pushd local-pipeline && bk local run ../.buildkite/local-pipeline.yml --meta-data "buildkite-perforce-revision=6"
 	$(MAKE) clean_p4d
 
 test:

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -51,7 +51,8 @@ def should_backup_changelists():
 
 def get_metadata(key):
     """If it exists, retrieve metadata from buildkite for a given key"""
-    if not __ACCESS_TOKEN__ or __LOCAL_RUN__:
+    if not __ACCESS_TOKEN__:
+        # Cannot get metadata outside of buildkite context
         return None
 
     if subprocess.call(['buildkite-agent', 'meta-data', 'exists', key]) == 0:
@@ -62,6 +63,7 @@ def set_metadata(key, value, overwrite=False):
         Returns true if data was written
     """
     if not __ACCESS_TOKEN__ or __LOCAL_RUN__:
+        # Cannot set metadata outside of buildkite context, including `bk local run`
         return False
 
     if overwrite or subprocess.call(['buildkite-agent', 'meta-data', 'exists', key]) == 100:
@@ -93,9 +95,6 @@ def set_build_changelist(changelist):
 
 def get_build_revision():
     """Get a p4 revision for the build to sync to"""
-    if __LOCAL_RUN__:
-        return 'HEAD'
-
     return get_metadata(__REVISION_METADATA__) or os.environ['BUILDKITE_COMMIT'] # metadata, HEAD or user-defined value
 
 def set_build_revision(revision):


### PR DESCRIPTION
* set metadata for which revision to sync (since you cannot set metadata outside of real buildkite context)
* allow this metadata to be picked up by utility functions