### PR TITLE
Accept all types of revision specifiers

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -102,9 +102,9 @@ def get_build_revision():
 
     revision = os.environ['BUILDKITE_COMMIT'] # HEAD, user-defined revision or git-sha
     # Convert bare changelist number to revision specifier
-    # Note: Theoretically, its possible for all 40 characters of a git sha to match this.
+    # Note: Theoretically, its possible for all 40 characters of a git sha to be digits.
     #       In practice, the inconvenience of forcing users to always include '@' outweighs this risk (~1 in 7 billion)
-    if re.match(r'^\d*$', revision):
+    if revision.isdigit():
         revision = '@%s' % revision
     # Filter to only valid revision specifiers
     if revision.startswith('@') or revision.startswith('#'):

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -4,7 +4,6 @@ Entrypoint for checkout hook
 import os
 import argparse
 import subprocess
-import re
 
 from perforce import P4Repo
 from buildkite import (get_env, get_config, get_build_revision, set_build_revision,
@@ -19,14 +18,10 @@ def main():
     repo = P4Repo(**config)
 
     revision = get_build_revision()
-    if not revision.isdigit():
+    if revision is None:
         # Resolve 'HEAD' or ignore git sha and find a concrete revision
         revision = repo.head()
         set_build_revision(revision)
-
-    # Convert changelist number to revision specifier
-    if re.match(r'^\d*$', revision):
-        revision = '@%s' % revision
 
     repo.sync(revision=revision)
 

--- a/python/checkout.py
+++ b/python/checkout.py
@@ -19,7 +19,6 @@ def main():
 
     revision = get_build_revision()
     if revision is None:
-        # Resolve 'HEAD' or ignore git sha and find a concrete revision
         revision = repo.head()
         set_build_revision(revision)
 


### PR DESCRIPTION
Docs on revision specifiers:
https://www.perforce.com/manuals/v17.1/cmdref/Content/CmdRef/filespecs.synopsis.using_revision_specifiers.html?TocPath=File%20Specifications%7C_____3

* move logic out of checkout.py and into buildkite.py (since its buildkite-context-specific)
* handle more revision specifiers than a plain changelist number
* resolves internal issue ENG-2799

testing strategy:
integration test