### PR TITLE
Travis: Just run everything on one agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ before_install:
 install: 
   - pip install -r ./ci/requirements.txt
   - ./ci/install_$TRAVIS_OS_NAME.sh
-
-jobs:
-  include:
-    - stage: test
-      script: ./ci/test.sh
-    - script: ./ci/lint.sh
+script:
+  - ./ci/test.sh
+  - ./ci/lint.sh


### PR DESCRIPTION
* For free travis, we have a limit of 3 live agents
* The majority of the build is spinning up and provisioning the agent (~30s of 40s)
* Actual lint/tests take 3 and 10 seconds respectively, so the value of parallelizing is very low
* Having a sub-minute CI pipeline is sufficient - its basically always done by the time you go to click merge