### PR TITLE
Fix label syncing

### DIFF
--- a/python/checkout.py
+++ b/python/checkout.py
@@ -36,8 +36,10 @@ def main():
 
         repo.p4print_unshelve(changelist)
 
-    revision = get_build_revision()
-    description = repo.description(get_users_changelist() or revision.strip('@'))
+    description = repo.description(
+        # Prefer users change description over latest submitted change
+        get_users_changelist() or repo.head_at_revision(revision)
+    )
     set_build_info(revision, description)
 
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -169,9 +169,6 @@ class P4Repo:
     def description(self, changelist):
         """Get description of a given changelist"""
         # Resolve revision specifier to a concrete cl
-        head_revision = self.perforce.run_changes([
-            '-m', '1', 
-        ])
         return self.perforce.run_describe(str(changelist))[0]['desc']
 
     def sync(self, revision=None):

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -167,8 +167,7 @@ class P4Repo:
         return result[0]['change']
 
     def description(self, changelist):
-        """Get description of a given changelist"""
-        # Resolve revision specifier to a concrete cl
+        """Get description of a given changelist number"""
         return self.perforce.run_describe(str(changelist))[0]['desc']
 
     def sync(self, revision=None):


### PR DESCRIPTION
* metadata is only ever set to a valid revision specifier like '@labelname' or '@changelist', never just a bare cl like '1234'
* resolve head revision relative to a revision spec
* use this description

Avoids bug when syncing to a label it tries to get description of that label as if it were a changelist