### PR TITLE
Fix auto-resolve of HEAD

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -152,9 +152,9 @@ class P4Repo:
         # Get head based on client view (e.g. within the stream)
         client_head = self.head_at_revision('//%s/...' % self._get_clientname())
         if client_head:
-            return client_head
+            return '@' + client_head
         # Fallback for when client view has no submitted changes, global head revision
-        return self.perforce.run_counter("maxCommitChange")[0]['value']
+        return '@' + self.perforce.run_counter("maxCommitChange")[0]['value']
 
     def head_at_revision(self, revision):
         """Get head submitted changelist at revision specifier"""

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -165,10 +165,10 @@ def test_fixture(capsys, server):
 def test_head(server):
     """Test resolve of HEAD changelist"""
     repo = P4Repo()
-    assert repo.head() == "6", "Unexpected global HEAD revision"
+    assert repo.head() == "@6", "Unexpected global HEAD revision"
 
     repo = P4Repo(stream='//stream-depot/main')
-    assert repo.head() == "2", "Unexpected HEAD revision for stream"
+    assert repo.head() == "@2", "Unexpected HEAD revision for stream"
 
     repo = P4Repo(stream='//stream-depot/idontexist')
     with pytest.raises(Exception, match=r"Stream '//stream-depot/idontexist' doesn't exist."):


### PR DESCRIPTION
Otherwise tries to sync `//...1234` instead of `//...@1234`