### PR TITLE
Sanitize revision specifier for use as `BUILDKITE_COMMIT`

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -119,4 +119,5 @@ def set_build_revision(revision):
 
 def set_build_info(revision, description):
     """Set the description and commit number in the UI for this build by mimicking a git repo"""
+    revision = revision.lstrip('@#') # revision must look like a git sha for buildkite to accept it
     set_metadata('buildkite:git:commit', 'commit %s\n\n\t%s' % (revision, description))


### PR DESCRIPTION
buildkite:git:commit metadata expects commit to be a git sha, then it will set BUILDKITE_COMMIT for following jobs in the build and update the UI to show this revision on the build

Right now, if a user tried to use BUILDKITE_COMMIT they would just get the value of `HEAD` every time