### PR TITLE
Cleanup files marked for add in unshelved changes

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -187,7 +187,7 @@ class P4Repo:
     def revert(self):
         """Revert any pending changes in the workspace"""
         self._setup_client()
-        self.perforce.run_revert('//...')
+        self.perforce.run_revert('-w', '//...')
         patched = self._read_patched()
         if patched:
             self.perforce.run_clean(patched)


### PR DESCRIPTION
* Default behaviour is to leave files marked for add on disk
* This can cause breakages in following jobs
* Instead, use `revert -w` to ensure these are cleaned up
* Add unit test coverage for this functionality