### PR TITLE
Apply sync filter to p4print unshelve

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -244,12 +244,17 @@ class P4Repo:
         # Flag these files as modified
         self._write_patched(list(depot_to_local.values()))
 
+        # Turn sync spec info a prefix to filter out unwanted files
+        # e.g. //my-depot/dir/... => //my-depot/dir/
+        sync_prefix = self.sync_paths.rstrip('.')
+
         cmds = []
         for depotfile, localfile in depot_to_local.items():
             if os.path.isfile(localfile):
                 os.chmod(localfile, stat.S_IWRITE)
                 os.unlink(localfile)
-            cmds.append(('print', '-o', localfile, '%s@=%s' % (depotfile, changelist)))
+            if depotfile.startswith(sync_prefix):
+                cmds.append(('print', '-o', localfile, '%s@=%s' % (depotfile, changelist)))
 
         self.run_parallel_cmds(cmds)
 

--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -285,6 +285,12 @@ def test_p4print_unshelve(server, tmpdir):
         assert content.read() == "Hello World\n", "Unexpected content in workspace file"
     assert not os.path.exists(os.path.join(tmpdir, "newfile.txt")), "File unshelved for add was not deleted"
 
+    # Shelved changes containing files not selected for sync are skipped
+    repo = P4Repo(root=tmpdir, sync='//depot/fake-dir/...')
+    repo.sync()
+    repo.p4print_unshelve('3') # Modify file.txt
+    assert not os.path.exists(os.path.join(tmpdir, "file.txt"))
+
     # Shelved changes containing files not mapped into this workspace do not throw an exception
     repo = P4Repo(root=tmpdir, stream='//stream-depot/main')
     repo.p4print_unshelve('3') # Modify a file


### PR DESCRIPTION
When a sync filter has been provided to the plugin, skip unshelving files that don't match this.

This improves performance for build steps which don't need the entire changelist contents