### PR TITLE
Set clientname before performing p4 operations

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -76,6 +76,8 @@ class P4Repo:
         if self.created_client:
             return
         clientname = self._get_clientname()
+        # must be set prior to running any commands to avoid issues with default client names
+        self.perforce.client = clientname
         client = self.perforce.fetch_client(clientname)
         if self.root:
             client._root = self.root
@@ -89,7 +91,6 @@ class P4Repo:
         client._options = self.client_opts + ' clobber'
 
         self.perforce.save_client(client)
-        self.perforce.client = clientname
 
         if not os.path.isfile(self.p4config):
             self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")


### PR DESCRIPTION
Addresses exception in `fetch_client()`:
```
P4.P4Exception: [P4#run] Errors during command execution( "p4 client -o bk-p4-localhost-1-__stavka-mainline_dev" )
--
  |  
  | [Error]: "Purely numeric name not allowed - '127'."

```

Caused by invalid initial value of `client`:
```
$ p4 set
User name: buildmachine
Client name: 127 (illegal)
Client host: 127.0.0.1
Client unknown
```

For some reason the current client must have a valid name (but doesn't need to exist) in order to get information about another client.