### PR TITLE
Allow unshelving pending changelists for git-based pipelines

### DIFF
--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -26,8 +26,6 @@ def get_env():
         if plugin_value:
             env[p4var] = plugin_value
 
-    # Ignore p4config when checking out, as it can override the intended plugin config
-    env['P4CONFIG'] = ""
     return env
 
 def get_config():
@@ -38,6 +36,7 @@ def get_config():
     conf['sync'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SYNC')
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 0
     conf['client_opts'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
+    conf['shelved_change'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SHELVED_CHANGE')
 
     if 'BUILDKITE_PLUGIN_PERFORCE_ROOT' in os.environ and not __LOCAL_RUN__:
         raise Exception("Custom P4 root is for use in unit tests only")
@@ -77,6 +76,11 @@ def set_metadata(key, value, overwrite=False):
 
 def get_users_changelist():
     """Get the shelved changelist supplied by the user, if applicable"""
+    conf = get_config()
+    if conf['shelved_change']:
+        # Overrides the CL to unshelve via plugin config
+        return conf['shelved_change']
+
     branch = os.environ.get('BUILDKITE_BRANCH', '')
     if branch.isdigit():
         return branch

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -25,6 +25,9 @@ def get_env():
         plugin_value = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_%s' % p4var)
         if plugin_value:
             env[p4var] = plugin_value
+
+    # Ignore p4config when checking out, as it can override the intended plugin config
+    env['P4CONFIG'] = ""
     return env
 
 def get_config():
@@ -104,13 +107,14 @@ def get_build_revision():
     # Convert bare changelist number to revision specifier
     # Note: Theoretically, its possible for all 40 characters of a git sha to be digits.
     #       In practice, the inconvenience of forcing users to always include '@' outweighs this risk (~1 in 7 billion)
+    
     if revision.isdigit():
         revision = '@%s' % revision
     # Filter to only valid revision specifiers
     if revision.startswith('@') or revision.startswith('#'):
         return revision
     # Unable to establish a concrete revision for the build
-    return None 
+    return None
 
 def set_build_revision(revision):
     """Set the p4 revision for following jobs in this build"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -110,14 +110,13 @@ def get_build_revision():
     # Convert bare changelist number to revision specifier
     # Note: Theoretically, its possible for all 40 characters of a git sha to be digits.
     #       In practice, the inconvenience of forcing users to always include '@' outweighs this risk (~1 in 7 billion)
-
     if revision.isdigit():
         revision = '@%s' % revision
     # Filter to only valid revision specifiers
     if revision.startswith('@') or revision.startswith('#'):
         return revision
     # Unable to establish a concrete revision for the build
-    return None
+    return None 
 
 def set_build_revision(revision):
     """Set the p4 revision for following jobs in this build"""

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -25,7 +25,6 @@ def get_env():
         plugin_value = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_%s' % p4var)
         if plugin_value:
             env[p4var] = plugin_value
-
     return env
 
 def get_config():

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -110,7 +110,7 @@ def get_build_revision():
     # Convert bare changelist number to revision specifier
     # Note: Theoretically, its possible for all 40 characters of a git sha to be digits.
     #       In practice, the inconvenience of forcing users to always include '@' outweighs this risk (~1 in 7 billion)
-    
+
     if revision.isdigit():
         revision = '@%s' % revision
     # Filter to only valid revision specifiers

--- a/python/buildkite.py
+++ b/python/buildkite.py
@@ -35,7 +35,6 @@ def get_config():
     conf['sync'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SYNC')
     conf['parallel'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_PARALLEL') or 0
     conf['client_opts'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_CLIENT_OPTIONS')
-    conf['shelved_change'] = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SHELVED_CHANGE')
 
     if 'BUILDKITE_PLUGIN_PERFORCE_ROOT' in os.environ and not __LOCAL_RUN__:
         raise Exception("Custom P4 root is for use in unit tests only")
@@ -75,10 +74,11 @@ def set_metadata(key, value, overwrite=False):
 
 def get_users_changelist():
     """Get the shelved changelist supplied by the user, if applicable"""
-    conf = get_config()
-    if conf['shelved_change']:
-        # Overrides the CL to unshelve via plugin config
-        return conf['shelved_change']
+    # Overrides the CL to unshelve via plugin config
+    # TODO: Remove this to discourage git-based pipelines that sync perforce
+    shelved_cl = os.environ.get('BUILDKITE_PLUGIN_PERFORCE_SHELVED_CHANGE')
+    if shelved_cl:
+        return shelved_cl
 
     branch = os.environ.get('BUILDKITE_BRANCH', '')
     if branch.isdigit():


### PR DESCRIPTION
Normally, it is expected that the entire pipeline lives in perforce and `BUILDKITE_BRANCH` is the pending cl

Instead, allow configuring the plugin directly to unshelve a specific changelist

For now, I am leaving this as an undocumented feature to support an internal refactoring effort as it is not something we intend to support long-term.