### PR TITLE
Add example workspace cleanup script

### DIFF
--- a/examples/cleanup-unused-workspaces.py
+++ b/examples/cleanup-unused-workspaces.py
@@ -6,7 +6,7 @@ from P4 import P4
 from datetime import datetime, timedelta
 from pprint import pprint
 
-# delete workspaces where last access time < N days ago
+# delete workspaces where last access time > N days ago
 __days_unused__ = 30
 
 p4 = P4()

--- a/examples/cleanup-unused-workspaces.py
+++ b/examples/cleanup-unused-workspaces.py
@@ -1,0 +1,47 @@
+import sys
+import logging
+
+# Recommended reference: https://www.perforce.com/manuals/p4python/p4python.pdf
+from P4 import P4
+from datetime import datetime, timedelta
+from pprint import pprint
+
+# delete workspaces where last access time < N days ago
+__days_unused__ = 30
+
+p4 = P4()
+logger = logging.getLogger("p4python")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(
+    '%(asctime)s %(name)s %(levelname)s: %(message)s',
+    '%H:%M:%S',
+)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+p4.logger = logger
+
+p4.connect()
+
+clients = p4.run_clients()
+
+# Filter by basic prefix matching.
+# May want to include filtering by user and other fields to avoid false positives.
+bk_clients = [client for client in clients 
+              if client.get('client', '').startswith('bk-p4-')]
+
+now = datetime.now()
+n_days_ago = (now - timedelta(days=__days_unused__)).timestamp()
+unused_clients = [client for client in bk_clients
+                  if int(client.get('Access')) < n_days_ago]
+
+pprint(unused_clients)
+proceed = input("Will delete %d/%d Buildkite clients. Continue? (y/n) " % (len(unused_clients),len(bk_clients))).lower() == 'y'
+
+if proceed:
+    for client in unused_clients:
+        clientname = client.get('client')
+        try:
+            p4.run_client('-d', clientname)
+        except:
+            pass


### PR DESCRIPTION
This simple script can be used to delete client workspaces created by the plugin that have not been accessed in a given amount of time.

Makes the assumption that all workspaces with prefix `bk-p4-` are created by us. You can add to the comprehension for `bk_clients` for additional filtering based on user, workspace root etc.


## Why?

* For CI systems with ephemeral agents, client workspaces can build up over time
* This causes the db.have table to bloat in size, reducing server performance and increasing time to create checkpoints
* Relates to Issue #40 