### PR TITLE
Adding pre-exit hook to revert any open files

### DIFF
--- a/.buildkite/common
+++ b/.buildkite/common
@@ -1,0 +1,31 @@
+function get_python_bin() {
+   python_bin="python3"
+    if ! [[ -x "$(command -v ${python_bin})" ]]; then
+        python_bin="python"
+    fi
+    echo "${python_bin}"
+}
+
+function get_venv_dir() {
+    # Unique virtualenv for requirements.txt
+    venv_md5=$(md5sum "./python/requirements.txt" | awk '{print $1}')
+    venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv-${venv_md5}"
+    echo "${venv_dir}"
+}
+
+function get_venv_python_bin() {
+    python_bin=$(get_python_bin)
+    platform=$(${python_bin} -c "import platform; print(platform.system())")
+    if [[ "${platform}" == "Windows" ]]; then
+        venv_python_bin="/Scripts/python"
+    else
+        venv_python_bin="/bin/python"
+    fi
+    echo "${venv_python_bin}"
+}
+
+function get_python_path() {
+    venv_dir=$(get_venv_dir)
+    venv_python_bin=$(get_venv_python_bin)
+    echo "${venv_dir}${venv_python_bin}"
+}

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -3,12 +3,9 @@ set -eo pipefail
 
 plugin_root="${BASH_SOURCE%/*}/.."
 
+source ${plugin_root}/common
 
-# Try to use explicit python3 if its installed
-python_bin="python3"
-if ! [[ -x "$(command -v ${python_bin})" ]]; then
-    python_bin="python"
-fi
+python_bin=$(get_python_bin)
 
 # Ensure some version of virtualenv is installed
 # Lazy install avoids races between different jobs wanting different versions
@@ -17,15 +14,9 @@ if [[ ! $(${python_bin} -m pip freeze) =~ "virtualenv==" ]]; then
 fi
 
 # Unique virtualenv for requirements.txt
-venv_md5=$(md5sum "${plugin_root}/python/requirements.txt" | awk '{print $1}')
-venv_dir="${BUILDKITE_BUILD_CHECKOUT_PATH}/../.perforce-plugin-venv-${venv_md5}"
+venv_dir=$(get_venv_dir)
 
-platform=$(${python_bin} -c "import platform; print(platform.system())")
-if [[ "${platform}" == "Windows" ]]; then
-    venv_python_bin="/Scripts/python"
-else
-    venv_python_bin="/bin/python"
-fi
+venv_python_bin=$(get_venv_python_bin)
 
 if ! [[ -d "${venv_dir}" ]]; then
     temp_venv_dir=$(mktemp -d -t perforce-plugin-venv-XXXXXX)
@@ -38,4 +29,5 @@ if ! [[ -d "${venv_dir}" ]]; then
     echo "virtualenv created at ${venv_dir}"
 fi
 
-${venv_dir}${venv_python_bin} "${plugin_root}/python/checkout.py"
+python_path=$(get_python_path)
+${python_path} "${plugin_root}/python/checkout.py"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eo pipefail
+
+echo "Reverting any files still open"
+p4 revert //...

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
+plugin_root="${BASH_SOURCE%/*}/.."
+
+source ${plugin_root}/common
+
 echo "Reverting any files still open"
-p4 revert //...
+python_path=$(get_python_path)
+${python_path} "${plugin_root}/python/checkout.py"

--- a/python/pre-exit.py
+++ b/python/pre-exit.py
@@ -1,0 +1,18 @@
+"""
+Entrypoint for pre-exit hook
+"""
+import os
+
+from perforce import P4Repo
+from buildkite import (get_env, get_config)
+
+def main():
+    """Main"""
+    os.environ.update(get_env())
+    config = get_config()
+
+    repo = P4Repo(**config)
+    repo.revert()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Revert any files still open in the pre-exit step. This should fix errors stemming from steps leaving the workspace in a bad state (such as a submit failure) see: https://buildkite.com/improbable/midwinter-editor/builds/1268#b45d1365-e8b7-4f8f-80ba-a0b329c641ef/577-654