### PR TITLE
Force in case the client has files open

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -90,9 +90,9 @@ class P4Repo:
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_opts + ' clobber'
 
-        self.perforce..input = client
+        self.perforce.input = client
         # force in case the client has files open
-        self.perforce..run_client( "-f -i" )
+        self.perforce.run_client( "-f -i" )
 
         if not os.path.isfile(self.p4config):
             self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -90,9 +90,8 @@ class P4Repo:
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_opts + ' clobber'
 
-        self.perforce.input = client
         # force in case the client has files open
-        self.perforce.run_client( "-f -i" )
+        self.perforce.save_client(client, '-f')
 
         if not os.path.isfile(self.p4config):
             self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -90,7 +90,9 @@ class P4Repo:
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_opts + ' clobber'
 
-        self.perforce.save_client(client)
+        self.perforce..input = client
+        # force in case the client has files open
+        self.perforce..run_client( "-f -i" )
 
         if not os.path.isfile(self.p4config):
             self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")


### PR DESCRIPTION
force switching of client in case it has files open:

> 1:26:27 p4python INFO: p4 client -i
> --
>   | 01:26:27 p4python ERROR: Client 'bk-p4-bk-202da96aeba5e06495bafd3026c0e8f1972eefa7-280w-1-midwinter' has files opened; use -f to force switch.

see: https://buildkite.com/improbable/midwinter-code/builds/509#7eebf067-9610-47cb-8090-a5193b393e4d/204-210