### PR TITLE
Revert "Force in case the client has files open"

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -90,8 +90,7 @@ class P4Repo:
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_opts + ' clobber'
 
-        # force in case the client has files open
-        self.perforce.save_client(client, '-f')
+        self.perforce.save_client(client)
 
         if not os.path.isfile(self.p4config):
             self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")


### PR DESCRIPTION
Reverts improbable-eng/perforce-buildkite-plugin#176

`p4python ERROR: You don't have permission for this operation.`

as seen here: https://buildkite.com/improbable/midwinter-manual-build/builds/193#8a602bb0-7252-45cf-8da2-dda35ff7c681/175-200