### PR TITLE
ENG-3659 Disable tmp cleanup for P4Python connections

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -34,6 +34,7 @@ class P4Repo:
         self.p4config = os.path.join(self.root, 'p4config')
 
         self.perforce = P4()
+        self.perforce.disable_tmp_cleanup() # Required to use multiple P4 connections in parallel safely
         self.perforce.exception_level = 1  # Only errors are raised as exceptions
         logger = logging.getLogger("p4python")
         logger.setLevel(logging.INFO)


### PR DESCRIPTION
Confirmed to resolve issue where we occasionally get segfaults when using many p4 connections.

From [release notes](http://12.234.39.160/perforce/r15.2/doc/user/p4pythonnotes.txt)
> Added P4.disable_tmp_cleanup to prevent cleanup if temporary objects.
> Invoke this before connecting if you are using multiple P4 connections
> in parallel in a multi-threaded Python application.

We only need to call this once in the scripts lifetime, not for each connection.
