### PR TITLE
Resolve head revision at label directly

### DIFF
--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -198,6 +198,8 @@ def test_head(server, tmpdir):
     with pytest.raises(Exception, match=r"Stream '//stream-depot/idontexist' doesn't exist."):
         repo.head()
 
+    assert repo.head_at_revision("@my-label") == "2", "Unexpected HEAD revision for label"
+
 def test_checkout(server, tmpdir):
     """Test normal flow of checking out files"""
     repo = P4Repo(root=tmpdir)


### PR DESCRIPTION
Duplicates https://github.com/improbable-eng/perforce-buildkite-plugin/pull/172

Improves performance dramatically for resolving automatic labels, by first resolving its revision then looking up last submitted at that revision.

In our case, improves 37s -> 3s for one of our most widely used labels.

Implementation allows to always safely fallback to the default behaviour, so minimal risk to making this change (other than ~1s of overhead in situations where the revision spec looks like a label but isnt, which is pretty rare)


Results of profiling:
```
# Get last submitted revision at label
$ time p4 changes -m 1 -s submitted @LABEL
Change 1694
37s

# Get revision of automatic label
$ time p4 label -o LABEL
Revision: @1694
2s

# Get last submitted revision at concrete revision
$ time p4 changes -m 1 -s submitted @1694
Change 1694
1s
```