### PR TITLE
Skip unecessary flush for brand new client workspaces

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -93,17 +93,17 @@ class P4Repo:
 
         self.perforce.save_client(client)
 
-        if not os.path.isfile(self.p4config):
-            self.perforce.logger.warning("p4config missing, flushing workspace to revision zero")
-            self.perforce.run_flush(['//...@0'])
-        else:
+        if os.path.isfile(self.p4config):
             with open(self.p4config) as infile:
                 prev_clientname = next(line.split('=', 1)[-1]
                     for line in infile.read().splitlines() # removes \n
                     if line.startswith('P4CLIENT='))
-                if prev_clientname != clientname:
-                    self.perforce.logger.warning("p4config last client was %s, flushing workspace to match" % prev_clientname)
-                    self.perforce.run_flush(['//...@%s' % prev_clientname])
+            if prev_clientname != clientname:
+                self.perforce.logger.warning("p4config last client was %s, flushing workspace to match" % prev_clientname)
+                self.perforce.run_flush(['//...@%s' % prev_clientname])
+        elif 'Update' in client: # client was accessed previously
+            self.perforce.logger.warning("p4config missing for previously accessed client workspace. flushing to revision zero")
+            self.perforce.run_flush(['//...@0'])
 
         self._write_p4config()
         self.created_client = True


### PR DESCRIPTION
The flush is for resiliency in the case where a machine previously created a client at this path, but its workspace files have gone missing.
(e.g. a different disk has been attached, someone manually deleted the workspace directory)

In the case where the client is brand new, this is not a concern, so we can skip doing the flush.

Observed to save ~20s in production for the first job taken by a fresh agent. `p4 flush` can take a while for large repos, even when its a no-op.

Changes:
* Flip condition in `if` statement
* Driveby unindent some code that was unecessarily inside `with open():` 
* Add `if 'Update' in client` condition - only clients that already existed have an `Update` field. We can assume the client it at revision zero when this is missing.
* Reword warning message to reflect changes
