### PR TITLE
Workflow improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_size = 2

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+# https://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations
+[flake8]
+ignore =
+    # don't care about line length.
+    E501

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 # https://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations
+# +
+# https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-length
 [flake8]
-ignore =
-    # don't care about line length.
-    E501
+# black wraps at 88
+max-line-length = 90
+extend-ignore = E203

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# make github collapse diffs for generated files within PRs
+# https://github.com/github/linguist#generated-code
+
+# make github know about vendored code
+# https://github.com/github/linguist#vendored-code
+**/vendor/** linguist-vendored
+
+# OWNERS files are YAML
+OWNERS linguist-language=Yaml
+**/OWNERS linguist-language=Yaml
+OWNERS_ALIASES linguist-language=Yaml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /ci
+    schedule:
+      interval: daily
+  - package-ecosystem: pip
+    directory: /python
+    schedule:
+      interval: daily

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: vendor
 
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.25.0
     hooks:
       - id: yamllint
         args:
@@ -16,7 +16,7 @@ repos:
           - --strict
 
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-    rev: 0.0.10  # or higher tag
+    rev: 0.1.0  # or higher tag
     hooks:
       - id: yamlfmt
         args:
@@ -27,7 +27,7 @@ repos:
         exclude: repocop.yaml
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.3.0
     hooks:
       - id: check-added-large-files
       - id: check-byte-order-marker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,8 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,73 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+# ignore:
+# vendor'd code (that has vendor in its path)
+exclude: vendor
+
+repos:
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.20.0
+    hooks:
+      - id: yamllint
+        args:
+          - --format=parsable
+          - --strict
+
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.0.10  # or higher tag
+    hooks:
+      - id: yamlfmt
+        args:
+          - --mapping=2
+          - --sequence=4
+          - --offset=2
+          - --width=1200    # match .yamllint.yaml; we don't care about line-length.
+        exclude: repocop.yaml
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: trailing-whitespace
+
+  - repo: https://github.com/syntaqx/git-hooks
+    rev: v0.0.16
+    hooks:
+      - id: forbid-binary
+        # Exclude png and snapshots forbid, we can check these in.
+        exclude: ^.+\.(png|snapshot)$
+      # See checks in shellcheck wiki: https://github.com/koalaman/shellcheck/wiki/
+      - id: shellcheck
+      - id: shfmt
+        # do not use these args (yet):
+        # -s, simplify code
+        # -mn, minify to reduce its size
+        args:
+          - -w      # autofix in place
+          - -d      # show diff
+          - -i=2    # indent 2 spaces
+
+  - repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.6.0
+    hooks:
+      - id: pylint
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,5 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        args:
+          - --skip-string-normalization

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,8 @@ repos:
     rev: v0.0.16
     hooks:
       - id: forbid-binary
-        # Exclude png and snapshots forbid, we can check these in.
-        exclude: ^.+\.(png|snapshot)$
+        # Exclude png and server.zip forbid, we can check these in.
+        exclude: ^.+\.(png|server\.zip)$
       # See checks in shellcheck wiki: https://github.com/koalaman/shellcheck/wiki/
       - id: shellcheck
       - id: shfmt

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,18 @@
+---
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - .toolsharerc
+  - .yamllint.yaml
+  - '*.yaml'
+  - '*.yml'
+  - OWNERS_ALIASES
+  - OWNERS
+
+rules:
+  document-start:
+    level: error
+  line-length:
+    max: 1200
+    level: warning

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,2 +1,3 @@
+pre-commit==2.7.1
 pytest==4.5.0
 pylint==2.3.1


### PR DESCRIPTION
## Changes

* dependabot for dependencies
* pre-commit for local workflow, plus configuration files - note, no onboarding instructions yet - things are assumed to be installable via pre-commit or on PATH already.

## Verification

Note - this just introduces it. Followups will clear up the exposed lint etc. Things that autofix would go first, then CI would get turned on for incremental pre-commit.

```
$ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/adrienverge/yamllint.
[INFO] Initializing environment for https://github.com/jumanjihouse/pre-commit-hook-yamlfmt.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/syntaqx/git-hooks.
[INFO] Initializing environment for https://github.com/syntaqx/git-hooks:shellcheck.
[INFO] Initializing environment for https://github.com/syntaqx/git-hooks:shfmt.
[INFO] Initializing environment for https://github.com/PyCQA/pylint.
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
[INFO] Installing environment for https://github.com/adrienverge/yamllint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/jumanjihouse/pre-commit-hook-yamlfmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pylint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
yamllint.................................................................Failed
- hook id: yamllint
- exit code: 1

.buildkite/local-pipeline.yml:1:1: [error] missing document start "---" (document-start)
.buildkite/local-pipeline.yml:13:31: [warning] truthy value should be one of [false, true] (truthy)
.buildkite/local-pipeline.yml:15:3: [warning] comment not indented like content (comments-indentation)
.buildkite/local-pipeline.yml:22:33: [error] no new line character at the end of file (new-line-at-end-of-file)
plugin.yml:1:1: [error] missing document start "---" (document-start)
.travis.yml:1:1: [error] missing document start "---" (document-start)
.travis.yml:9:9: [error] trailing spaces (trailing-spaces)

Format YAML files........................................................Failed
- hook id: yamlfmt
- files were modified by this hook

.buildkite/local-pipeline.yml  Done
.pre-commit-config.yaml  Done
plugin.yml  Done
.github/dependabot.yml  Done
.travis.yml  Done
.yamllint.yaml  Done

Check for added large files..............................................Passed
Check for byte-order marker..............................................Passed
Check for case conflicts.................................................Passed
Check that executables have shebangs.....................................Failed
- hook id: check-executables-have-shebangs
- exit code: 1

hooks/environment: marked executable but has no (or invalid) shebang!
  If it isn't supposed to be executable, try: chmod -x hooks/environment
  If it is supposed to be executable, double-check its shebang.

Check JSON...........................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for broken symlinks............................(no files to check)Skipped
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing .editorconfig
Fixing hooks/pre-checkout

Forbid new submodules....................................................Passed
Mixed line ending........................................................Passed
Pretty format JSON...................................(no files to check)Skipped
Trim Trailing Whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing python/test_perforce.py
Fixing python/perforce.py
Fixing examples/cleanup-unused-workspaces.py
Fixing python/buildkite.py
Fixing examples/buildkite-trigger.py

Forbid binaries..........................................................Failed
- hook id: forbid-binary
- exit code: 1

[ERROR] python/fixture/server.zip appears to be a binary file

Test shell scripts with shellcheck.......................................Failed
- hook id: shellcheck
- exit code: 1

ERRO Failed to fetch GCS OIDC params to "/Users/petermounce/.improbable/imp-tool/gcs_oidc_params", will use old cached ones if they exist.
   > time=2020-10-20T23:14:21+01:00
   ! error (Unknown): failed to create new vault config
   ! {code = Unknown desc = failed to create new vault config}
   ! {code = Unknown desc = Failed to authenticate to vault via GCP, OIDC, and AWS auth, check the relevant error message. GCP is used in BuildKite, OIDC locally on workstations in IO silo, and AWS locally on workstations in CN silo.}
   ! {code = Unknown details = {
   ! 	{code = Unknown desc = failed to create GCP IAM token provider}
   ! 	{code = Unknown desc = failed to create JWT token source}
   ! 	{code = Unknown desc = google: could not parse JSON key: google: read JWT from JSON credentials: 'type' field is "authorized_user" (expected "service_account")}
   ! 	{code = Unknown desc = failed to create vault client}
   ! 	{code = Unknown desc = failed to create oidc provider}
   ! 	{code = Unknown desc = failed to create OIDC CallbackServer; Failed to Listen for tcp on: 127.0.0.1:8079. Err: listen tcp 127.0.0.1:8079: bind: address already in use}
   ! 	{code = Unknown desc = Failed to Listen for tcp on: 127.0.0.1:8079. Err: listen tcp 127.0.0.1:8079: bind: address already in use}
   ! 	{code = Unknown desc = failed to create vault client}
   ! 	{code = Unknown desc = failed to auth to vault via AWS auth mechanism}
   ! 	{code = Unknown desc = failed to generate AWS login data for Vault}
   ! 	{code = Unknown desc = NoCredentialProviders: no valid providers in chain. Deprecated.
   ! 	For verbose messaging see aws.Config.CredentialsChainVerboseErrors}}}

In hooks/checkout line 32:
    trap "rm -rf ${temp_venv_dir}" EXIT
                 ^--------------^ SC2064: Use single quotes, otherwise this expands now rather than when signalled.


In hooks/checkout line 34:
    ${temp_venv_dir}${venv_python_bin} -m pip install -r "${plugin_root}/python/requirements.txt"
    ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    "${temp_venv_dir}"${venv_python_bin} -m pip install -r "${plugin_root}/python/requirements.txt"


In hooks/checkout line 41:
${venv_dir}${venv_python_bin} "${plugin_root}/python/checkout.py"
^---------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
"${venv_dir}"${venv_python_bin} "${plugin_root}/python/checkout.py"

For more information:
  https://www.shellcheck.net/wiki/SC2064 -- Use single quotes, otherwise this...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In hooks/pre-checkout line 20:
      SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().split('/')[2]);")
                              ^-----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
      SANITIZED_STREAM=$(echo "$STREAM" | python -c "import sys; print(sys.stdin.read().split('/')[2]);")


In hooks/pre-checkout line 23:
      SANITIZED_STREAM=$(echo $STREAM | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")
                              ^-----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
      SANITIZED_STREAM=$(echo "$STREAM" | python -c "import sys; print(sys.stdin.read().replace('/', '_'));")


In dev/setup_env_osx.sh line 34:
    echo "WARNING: `bk` cli is not installed. https://github.com/buildkite/cli"
                   ^--^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
    echo "WARNING: $(bk) cli is not installed. https://github.com/buildkite/cli"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...

Check shell style with shfmt.............................................Failed
- hook id: shfmt
- exit code: 1
- files were modified by this hook

[RUN] shfmt -w -d -i=2 ci/install_linux.sh ci/test.sh hooks/checkout ci/lint.sh
[RUN] shfmt -w -d -i=2 hooks/pre-checkout dev/setup_env_osx.sh examples/buildkite-trigger.sh

pylint...................................................................Failed
- hook id: pylint
- exit code: 30

************* Module buildkite-trigger
examples/buildkite-trigger.py:3:0: C0301: Line too long (118/100) (line-too-long)
examples/buildkite-trigger.py:33:0: C0301: Line too long (105/100) (line-too-long)
examples/buildkite-trigger.py:1:0: C0103: Module name "buildkite-trigger" doesn't conform to snake_case naming style (invalid-name)
examples/buildkite-trigger.py:1:0: C0114: Missing module docstring (missing-module-docstring)
************* Module buildkite
python/buildkite.py:95:2: W0511: TODO: Remove this to discourage git-based pipelines that sync perforce (fixme)
python/buildkite.py:15:0: C0301: Line too long (117/100) (line-too-long)
python/buildkite.py:58:0: C0301: Line too long (118/100) (line-too-long)
python/buildkite.py:78:0: C0301: Line too long (113/100) (line-too-long)
python/buildkite.py:129:0: C0301: Line too long (119/100) (line-too-long)
python/buildkite.py:68:0: C0116: Missing function or method docstring (missing-function-docstring)
python/buildkite.py:71:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
python/buildkite.py:80:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
python/buildkite.py:92:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
python/buildkite.py:7:0: W0611: Unused import re (unused-import)
python/buildkite.py:8:0: W0611: Unused datetime imported from datetime (unused-import)
************* Module test_perforce
python/test_perforce.py:92:0: C0301: Line too long (107/100) (line-too-long)
python/test_perforce.py:105:0: C0301: Line too long (105/100) (line-too-long)
python/test_perforce.py:115:0: C0301: Line too long (126/100) (line-too-long)
python/test_perforce.py:157:0: C0301: Line too long (128/100) (line-too-long)
python/test_perforce.py:226:0: C0301: Line too long (103/100) (line-too-long)
python/test_perforce.py:283:0: C0301: Line too long (106/100) (line-too-long)
python/test_perforce.py:292:0: C0301: Line too long (102/100) (line-too-long)
python/test_perforce.py:309:0: C0301: Line too long (116/100) (line-too-long)
python/test_perforce.py:340:0: C0301: Line too long (108/100) (line-too-long)
python/test_perforce.py:369:0: C0301: Line too long (108/100) (line-too-long)
python/test_perforce.py:435:0: C0301: Line too long (101/100) (line-too-long)
python/test_perforce.py:457:0: C0301: Line too long (105/100) (line-too-long)
python/test_perforce.py:14:0: E0401: Unable to import 'pytest' (import-error)
python/test_perforce.py:45:4: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:70:62: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:76:4: C0103: Variable name "serverRoot" doesn't conform to snake_case naming style (invalid-name)
python/test_perforce.py:85:25: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:195:14: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:195:22: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:195:14: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:210:18: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:210:26: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:210:18: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:228:31: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:228:39: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:228:31: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:234:30: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:234:38: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:234:30: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:240:35: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:240:43: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:240:35: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:246:25: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:246:33: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:246:25: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:255:24: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:255:32: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:255:24: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:266:25: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:266:33: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:266:25: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:272:28: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:272:36: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:272:28: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:278:28: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:278:36: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:278:28: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:287:28: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:287:36: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:287:28: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:313:18: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:313:26: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:313:18: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:343:26: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:343:34: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:363:15: W0212: Access to a protected member _read_patched of a client class (protected-access)
python/test_perforce.py:343:26: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:381:23: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:381:31: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:381:23: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:396:8: C0103: Variable name "s" doesn't conform to snake_case naming style (invalid-name)
python/test_perforce.py:397:8: C0103: Variable name "d" doesn't conform to snake_case naming style (invalid-name)
python/test_perforce.py:403:26: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:403:34: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:403:26: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:418:26: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:418:34: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:418:26: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:437:36: W0621: Redefining name 'server' from outer scope (line 58) (redefined-outer-name)
python/test_perforce.py:437:44: W0621: Redefining name 'tmpdir' from outer scope (line 68) (redefined-outer-name)
python/test_perforce.py:437:36: W0613: Unused argument 'server' (unused-argument)
python/test_perforce.py:4:0: W0611: Unused contextmanager imported from contextlib (unused-import)
************* Module cleanup-unused-workspaces
examples/cleanup-unused-workspaces.py:39:0: C0301: Line too long (127/100) (line-too-long)
examples/cleanup-unused-workspaces.py:1:0: C0103: Module name "cleanup-unused-workspaces" doesn't conform to snake_case naming style (invalid-name)
examples/cleanup-unused-workspaces.py:1:0: C0114: Missing module docstring (missing-module-docstring)
examples/cleanup-unused-workspaces.py:5:0: E0401: Unable to import 'P4' (import-error)
examples/cleanup-unused-workspaces.py:46:8: W0702: No exception type(s) specified (bare-except)
examples/cleanup-unused-workspaces.py:6:0: C0411: standard import "from datetime import datetime, timedelta" should be placed before "from P4 import P4" (wrong-import-order)
examples/cleanup-unused-workspaces.py:7:0: C0411: standard import "from pprint import pprint" should be placed before "from P4 import P4" (wrong-import-order)
************* Module checkout
python/checkout.py:5:0: W0611: Unused import argparse (unused-import)
python/checkout.py:6:0: W0611: Unused import subprocess (unused-import)
************* Module perforce
python/perforce.py:57:2: W0511: TODO: Remove this and enforce prior provisioning of trusted fingerprints (fixme)
python/perforce.py:167:2: W0511: TODO: Add a fast implementation of p4 clean here (fixme)
python/perforce.py:43:0: C0301: Line too long (104/100) (line-too-long)
python/perforce.py:65:0: C0301: Line too long (128/100) (line-too-long)
python/perforce.py:85:0: C0301: Line too long (160/100) (line-too-long)
python/perforce.py:125:0: C0301: Line too long (122/100) (line-too-long)
python/perforce.py:129:0: C0301: Line too long (128/100) (line-too-long)
python/perforce.py:253:0: C0301: Line too long (109/100) (line-too-long)
python/perforce.py:310:0: C0301: Line too long (110/100) (line-too-long)
python/perforce.py:16:0: R0902: Too many instance attributes (11/7) (too-many-instance-attributes)
python/perforce.py:18:4: R0913: Too many arguments (8/5) (too-many-arguments)
python/perforce.py:83:40: W0212: Access to a protected member _stream of a client class (protected-access)
python/perforce.py:85:126: W0212: Access to a protected member _stream of a client class (protected-access)
python/perforce.py:86:12: W0212: Access to a protected member _stream of a client class (protected-access)
python/perforce.py:86:37: W0212: Access to a protected member _stream of a client class (protected-access)
python/perforce.py:93:12: W0212: Access to a protected member _stream of a client class (protected-access)
python/perforce.py:258:4: C0116: Missing function or method docstring (missing-function-docstring)
python/perforce.py:267:8: C0415: Import outside toplevel (concurrent.futures.ThreadPoolExecutor) (import-outside-toplevel)
python/perforce.py:308:8: W0212: Access to a protected member _description of a client class (protected-access)
python/perforce.py:323:25: W0621: Redefining name 'stat' from outer scope (line 9) (redefined-outer-name)
python/perforce.py:323:4: C0103: Method name "outputStat" doesn't conform to snake_case naming style (invalid-name)
python/perforce.py:323:4: C0116: Missing function or method docstring (missing-function-docstring)
python/perforce.py:316:0: R0903: Too few public methods (1/2) (too-few-public-methods)
python/perforce.py:1:0: R0801: Similar lines in 2 files
==cleanup-unused-workspaces:12
==perforce:44
logger = logging.getLogger("p4python")
logger.setLevel(logging.INFO)
handler = logging.StreamHandler(sys.stdout)
formatter = logging.Formatter(
    '%(asctime)s %(name)s %(levelname)s: %(message)s',
    '%H:%M:%S',
)
handler.setFormatter(formatter)
logger.addHandler(handler) (duplicate-code)

-------------------------------------------------------------------
Your code has been rated at 7.92/10 (previous run: 10.00/10, -2.08)

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

examples/buildkite-trigger.py:3:80: E501 line too long (118 > 79 characters)
examples/buildkite-trigger.py:19:80: E501 line too long (94 > 79 characters)
examples/buildkite-trigger.py:33:80: E501 line too long (105 > 79 characters)
python/buildkite.py:7:1: F401 're' imported but unused
python/buildkite.py:8:1: F401 'datetime.datetime' imported but unused
python/buildkite.py:15:65: E261 at least two spaces before inline comment
python/buildkite.py:15:80: E501 line too long (117 > 79 characters)
python/buildkite.py:19:1: E302 expected 2 blank lines, found 1
python/buildkite.py:30:1: E302 expected 2 blank lines, found 1
python/buildkite.py:34:24: E261 at least two spaces before inline comment
python/buildkite.py:46:1: E302 expected 2 blank lines, found 1
python/buildkite.py:47:80: E501 line too long (86 > 79 characters)
python/buildkite.py:49:80: E501 line too long (82 > 79 characters)
python/buildkite.py:52:80: E501 line too long (80 > 79 characters)
python/buildkite.py:53:80: E501 line too long (87 > 79 characters)
python/buildkite.py:54:80: E501 line too long (81 > 79 characters)
python/buildkite.py:58:80: E501 line too long (118 > 79 characters)
python/buildkite.py:61:5: E303 too many blank lines (2)
python/buildkite.py:68:1: E302 expected 2 blank lines, found 1
python/buildkite.py:69:80: E501 line too long (92 > 79 characters)
python/buildkite.py:71:1: E302 expected 2 blank lines, found 1
python/buildkite.py:78:80: E501 line too long (113 > 79 characters)
python/buildkite.py:80:1: E302 expected 2 blank lines, found 1
python/buildkite.py:81:80: E501 line too long (82 > 79 characters)
python/buildkite.py:85:80: E501 line too long (84 > 79 characters)
python/buildkite.py:88:80: E501 line too long (92 > 79 characters)
python/buildkite.py:92:1: E302 expected 2 blank lines, found 1
python/buildkite.py:104:1: E302 expected 2 blank lines, found 1
python/buildkite.py:105:80: E501 line too long (87 > 79 characters)
python/buildkite.py:108:1: E302 expected 2 blank lines, found 1
python/buildkite.py:109:80: E501 line too long (83 > 79 characters)
python/buildkite.py:110:80: E501 line too long (86 > 79 characters)
python/buildkite.py:121:1: E302 expected 2 blank lines, found 1
python/buildkite.py:125:80: E501 line too long (80 > 79 characters)
python/buildkite.py:128:80: E501 line too long (88 > 79 characters)
python/buildkite.py:129:80: E501 line too long (119 > 79 characters)
python/buildkite.py:138:1: E302 expected 2 blank lines, found 1
python/buildkite.py:143:1: E302 expected 2 blank lines, found 1
python/buildkite.py:144:80: E501 line too long (96 > 79 characters)
python/buildkite.py:145:37: E261 at least two spaces before inline comment
python/buildkite.py:145:80: E501 line too long (99 > 79 characters)
python/buildkite.py:146:80: E501 line too long (87 > 79 characters)
python/test_perforce.py:4:1: F401 'contextlib.contextmanager' imported but unused
python/test_perforce.py:42:30: E261 at least two spaces before inline comment
python/test_perforce.py:61:80: E501 line too long (85 > 79 characters)
python/test_perforce.py:67:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:85:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:92:80: E501 line too long (107 > 79 characters)
python/test_perforce.py:95:80: E501 line too long (84 > 79 characters)
python/test_perforce.py:104:80: E501 line too long (81 > 79 characters)
python/test_perforce.py:105:80: E501 line too long (105 > 79 characters)
python/test_perforce.py:115:80: E501 line too long (126 > 79 characters)
python/test_perforce.py:120:18: E131 continuation line unaligned for hanging indent
python/test_perforce.py:123:12: E203 whitespace before ':'
python/test_perforce.py:123:13: E231 missing whitespace after ':'
python/test_perforce.py:128:12: E203 whitespace before ':'
python/test_perforce.py:128:13: E231 missing whitespace after ':'
python/test_perforce.py:133:12: E203 whitespace before ':'
python/test_perforce.py:133:13: E231 missing whitespace after ':'
python/test_perforce.py:141:80: E501 line too long (81 > 79 characters)
python/test_perforce.py:157:80: E501 line too long (128 > 79 characters)
python/test_perforce.py:162:18: E131 continuation line unaligned for hanging indent
python/test_perforce.py:165:12: E203 whitespace before ':'
python/test_perforce.py:165:13: E231 missing whitespace after ':'
python/test_perforce.py:171:12: E203 whitespace before ':'
python/test_perforce.py:171:13: E231 missing whitespace after ':'
python/test_perforce.py:176:12: E203 whitespace before ':'
python/test_perforce.py:176:13: E231 missing whitespace after ':'
python/test_perforce.py:188:29: E124 closing bracket does not match visual indentation
python/test_perforce.py:195:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:205:80: E501 line too long (94 > 79 characters)
python/test_perforce.py:208:80: E501 line too long (90 > 79 characters)
python/test_perforce.py:210:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:219:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:222:80: E501 line too long (82 > 79 characters)
python/test_perforce.py:226:80: E501 line too long (103 > 79 characters)
python/test_perforce.py:228:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:234:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:240:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:242:80: E501 line too long (81 > 79 characters)
python/test_perforce.py:246:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:253:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:255:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:259:80: E501 line too long (81 > 79 characters)
python/test_perforce.py:264:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:266:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:272:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:278:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:283:80: E501 line too long (106 > 79 characters)
python/test_perforce.py:287:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:292:80: E501 line too long (102 > 79 characters)
python/test_perforce.py:295:16: E261 at least two spaces before inline comment
python/test_perforce.py:297:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:304:80: E501 line too long (86 > 79 characters)
python/test_perforce.py:308:31: E261 at least two spaces before inline comment
python/test_perforce.py:308:80: E501 line too long (84 > 79 characters)
python/test_perforce.py:309:16: E261 at least two spaces before inline comment
python/test_perforce.py:309:80: E501 line too long (116 > 79 characters)
python/test_perforce.py:311:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:313:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:318:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:320:23: E261 at least two spaces before inline comment
python/test_perforce.py:322:80: E501 line too long (90 > 79 characters)
python/test_perforce.py:325:23: E261 at least two spaces before inline comment
python/test_perforce.py:329:23: E261 at least two spaces before inline comment
python/test_perforce.py:333:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:339:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:340:80: E501 line too long (108 > 79 characters)
python/test_perforce.py:344:80: E501 line too long (80 > 79 characters)
python/test_perforce.py:348:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:350:31: E261 at least two spaces before inline comment
python/test_perforce.py:352:80: E501 line too long (90 > 79 characters)
python/test_perforce.py:354:31: E261 at least two spaces before inline comment
python/test_perforce.py:357:31: E261 at least two spaces before inline comment
python/test_perforce.py:360:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:363:42: E261 at least two spaces before inline comment
python/test_perforce.py:368:80: E501 line too long (88 > 79 characters)
python/test_perforce.py:369:80: E501 line too long (108 > 79 characters)
python/test_perforce.py:374:31: E261 at least two spaces before inline comment
python/test_perforce.py:377:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:379:31: E261 at least two spaces before inline comment
python/test_perforce.py:381:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:390:80: E501 line too long (90 > 79 characters)
python/test_perforce.py:403:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:413:80: E501 line too long (80 > 79 characters)
python/test_perforce.py:415:29: E261 at least two spaces before inline comment
python/test_perforce.py:415:80: E501 line too long (96 > 79 characters)
python/test_perforce.py:416:80: E501 line too long (80 > 79 characters)
python/test_perforce.py:418:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:426:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:433:33: E261 at least two spaces before inline comment
python/test_perforce.py:435:80: E501 line too long (101 > 79 characters)
python/test_perforce.py:437:1: E302 expected 2 blank lines, found 1
python/test_perforce.py:445:80: E501 line too long (95 > 79 characters)
python/test_perforce.py:449:80: E501 line too long (80 > 79 characters)
python/test_perforce.py:450:80: E501 line too long (80 > 79 characters)
python/test_perforce.py:455:37: E261 at least two spaces before inline comment
python/test_perforce.py:457:80: E501 line too long (105 > 79 characters)
python/test_perforce.py:461:80: E501 line too long (96 > 79 characters)
examples/cleanup-unused-workspaces.py:29:80: E501 line too long (82 > 79 characters)
examples/cleanup-unused-workspaces.py:39:80: E501 line too long (127 > 79 characters)
examples/cleanup-unused-workspaces.py:39:95: E231 missing whitespace after ','
examples/cleanup-unused-workspaces.py:46:9: E722 do not use bare 'except'
python/checkout.py:5:1: F401 'argparse' imported but unused
python/checkout.py:6:1: F401 'subprocess' imported but unused
python/checkout.py:9:80: E501 line too long (83 > 79 characters)
python/checkout.py:10:5: E128 continuation line under-indented for visual indent
python/checkout.py:10:80: E501 line too long (85 > 79 characters)
python/checkout.py:11:5: E128 continuation line under-indented for visual indent
python/checkout.py:13:1: E302 expected 2 blank lines, found 1
python/perforce.py:14:46: E261 at least two spaces before inline comment
python/perforce.py:16:1: E302 expected 2 blank lines, found 1
python/perforce.py:43:44: E261 at least two spaces before inline comment
python/perforce.py:43:80: E501 line too long (104 > 79 characters)
python/perforce.py:44:80: E501 line too long (81 > 79 characters)
python/perforce.py:57:80: E501 line too long (86 > 79 characters)
python/perforce.py:65:80: E501 line too long (128 > 79 characters)
python/perforce.py:81:80: E501 line too long (88 > 79 characters)
python/perforce.py:85:80: E501 line too long (160 > 79 characters)
python/perforce.py:92:80: E501 line too long (82 > 79 characters)
python/perforce.py:102:80: E501 line too long (93 > 79 characters)
python/perforce.py:122:21: E128 continuation line under-indented for visual indent
python/perforce.py:122:59: E261 at least two spaces before inline comment
python/perforce.py:123:21: E128 continuation line under-indented for visual indent
python/perforce.py:125:80: E501 line too long (122 > 79 characters)
python/perforce.py:128:33: E261 at least two spaces before inline comment
python/perforce.py:129:80: E501 line too long (128 > 79 characters)
python/perforce.py:145:80: E501 line too long (80 > 79 characters)
python/perforce.py:148:80: E501 line too long (83 > 79 characters)
python/perforce.py:155:80: E501 line too long (85 > 79 characters)
python/perforce.py:156:58: E261 at least two spaces before inline comment
python/perforce.py:156:80: E501 line too long (83 > 79 characters)
python/perforce.py:168:80: E501 line too long (82 > 79 characters)
python/perforce.py:179:80: E501 line too long (80 > 79 characters)
python/perforce.py:182:80: E501 line too long (86 > 79 characters)
python/perforce.py:188:80: E501 line too long (82 > 79 characters)
python/perforce.py:194:18: E114 indentation is not a multiple of four (comment)
python/perforce.py:194:18: E116 unexpected indentation (comment)
python/perforce.py:206:24: E261 at least two spaces before inline comment
python/perforce.py:217:80: E501 line too long (82 > 79 characters)
python/perforce.py:225:80: E501 line too long (90 > 79 characters)
python/perforce.py:243:80: E501 line too long (93 > 79 characters)
python/perforce.py:252:80: E501 line too long (95 > 79 characters)
python/perforce.py:253:80: E501 line too long (109 > 79 characters)
python/perforce.py:256:9: E303 too many blank lines (2)
python/perforce.py:277:80: E501 line too long (93 > 79 characters)
python/perforce.py:283:80: E501 line too long (80 > 79 characters)
python/perforce.py:298:80: E501 line too long (91 > 79 characters)
python/perforce.py:308:80: E501 line too long (95 > 79 characters)
python/perforce.py:310:80: E501 line too long (110 > 79 characters)
python/perforce.py:325:28: E221 multiple spaces before operator
python/perforce.py:330:80: E501 line too long (95 > 79 characters)

(.dev-venv)
```