### PR TITLE
add live ops as co-owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,4 @@
 ---
 approvers:
   - team-eng-velocity
+  - team-live-ops

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,3 +10,11 @@ aliases:
     - Helcaraxan         # Duco van Amstel
     - PaulSonOfLars      # PaulSonOfLars
     - petemounce         # Peter Mounce
+  team-live-ops:
+    - LeadTimeNull       # Andreas Valentin Pedersen
+    - robbieheywood      # Robbie Heywood
+    - adamhosier         # Adam Hosier
+    - ianbillett         # Ian Billet
+    - jared-improbable   # Jared Dixey-Hefty
+    - tenevdev           # Tencho Tenev
+    - Christopher-Steel  # Christopher George Steel


### PR DESCRIPTION
Create owners alias for the live ops team; list all GH usernames, and comments with full names.