### PR TITLE
Disable osx builds due to travis now using Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ jobs:
     - os: linux
       language: python
       python: 3.6
-    - os: osx
-      language: shell
-      osx_image: xcode12.2 # macOS 10.15.7 Python 3.8.6
+# Disabled because this does not currently build successfully on MacOS due to p4python not getting along well with Python 3.9.
+#     - os: osx
+#       language: shell
+#       osx_image: xcode12u # macOS 10.15.5 Python 3.8.6
     - os: windows
       language: shell
       before_install:


### PR DESCRIPTION
And p4python does _not_ like Python 3.9.

https://github.com/improbable-eng/perforce-buildkite-plugin/pull/213 is a WIP PR to fix this, but it doesn't work right now, and I do not have the time to pick this up right now, unfortunately.

On my local machine:

With Python 3.8:
```bash
$ python3.8 --version
Python 3.8.5
$ python3.8 -m pip install -r ./python/requirements.txt
Collecting p4python==2020.1.2056111
  Downloading p4python-2020.1.2056111-cp38-cp38-macosx_10_12_x86_64.whl (2.7 MB)
     |████████████████████████████████| 2.7 MB 8.7 MB/s
Installing collected packages: p4python
Successfully installed p4python-2020.1.2056111
```

With Python 3.9:
```
$ python3.9 --version
Python 3.9.1
$ python3.9 -m pip install -r ./python/requirements.txt
Collecting p4python==2020.1.2056111
  Using cached p4python-2020.1.2056111.tar.gz (78 kB)
Building wheels for collected packages: p4python
  Building wheel for p4python (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/local/opt/python@3.9/bin/python3.9 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"'; __file__='"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-wheel-70_g9ygv
       cwd: /private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/
  Complete output (39 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.macosx-10.15-x86_64-3.9
  copying P4.py -> build/lib.macosx-10.15-x86_64-3.9
  running build_ext
  ***********************************************
  ** Cannot build P4Python without SSL support **
  ***********************************************
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 475, in <module>
      do_setup()
    File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 425, in do_setup
      setup(name=NAME,
    File "/usr/local/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 299, in run
      self.run_command('build')
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 292, in run
      raise Exception("Parameter --ssl is needed")
  Exception: Parameter --ssl is needed
  ----------------------------------------
  ERROR: Failed building wheel for p4python
  Running setup.py clean for p4python
Failed to build p4python
Installing collected packages: p4python
    Running setup.py install for p4python ... error
    ERROR: Command errored out with exit status 1:
     command: /usr/local/opt/python@3.9/bin/python3.9 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"'; __file__='"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-record-i820tyhw/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/p4python
         cwd: /private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/
    Complete output (41 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.macosx-10.15-x86_64-3.9
    copying P4.py -> build/lib.macosx-10.15-x86_64-3.9
    running build_ext
    ***********************************************
    ** Cannot build P4Python without SSL support **
    ***********************************************
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 475, in <module>
        do_setup()
      File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 425, in do_setup
        setup(name=NAME,
      File "/usr/local/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.9/site-packages/setuptools/command/install.py", line 61, in run
        return orig.install.run(self)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/command/install.py", line 546, in run
        self.run_command('build')
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/command/build.py", line 135, in run
        self.run_command(cmd_name)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py", line 292, in run
        raise Exception("Parameter --ssl is needed")
    Exception: Parameter --ssl is needed
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/local/opt/python@3.9/bin/python3.9 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"'; __file__='"'"'/private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-install-pbw134ul/p4python_5150ec888d5340f78a01f924156a7182/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/8g/9nt2bwb95yg0h610h_k1ldhm0000gn/T/pip-record-i820tyhw/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/p4python Check the logs for full command output.
```

