### PR TITLE
 Install python 3.8.0 explicitly in CI for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ jobs:
     - os: linux
       language: python
       python: 3.6
-# Disabled because this does not currently build successfully on MacOS due to p4python not getting along well with Python 3.9.
-#     - os: osx
-#       language: shell
-#       osx_image: xcode12u # macOS 10.15.5 Python 3.8.6
+    - os: osx
+      language: shell
+      osx_image: xcode12u # macOS 10.15.5
+      before_install:
+        - pyenv install 3.8.0
     - os: windows
       language: shell
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ jobs:
       language: shell
       osx_image: xcode12u # macOS 10.15.5
       before_install:
-        - pyenv install 3.8.0
+        - pyenv install 3.8.0 --skip-existing
+      cache:
+        directories:
+          # 'pyenv install' builds python from source; cache the result
+          - /Users/travis/.pyenv/versions/3.8.0
     - os: windows
       language: shell
       before_install:


### PR DESCRIPTION
Hey all - hope you are well 😃 

Pyenv is installed in the Travis OSX images (https://docs.travis-ci.com/user/reference/osx/#python-related-tools)

We can use it to pin the version of python used there, since it seems like this is subject to change.

Also, we can cache the python 3.8.0 that pyenv installs to save ~3 mins of what appears to be building it.

There aren't any precompiled binaries distributed for p4python on osx at 3.9, so it was wanting the full build dependencies of p4api etc to be installed. 😅

Lifes too short to build everything from source!