### PR TITLE
Attempt revert before saving client

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -126,7 +126,7 @@ class P4Repo:
         client._options = self.client_options + ' clobber'
         
         # revert changes in client before saving to avoid an error if files are still open in client
-        self.revert()
+        self.perforce.run_revert('-w', '//...')
 
         self.perforce.save_client(client)
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -126,7 +126,11 @@ class P4Repo:
         client._options = self.client_options + ' clobber'
         
         # revert changes in client before saving to avoid an error if files are still open in client
-        self.perforce.run_revert('-w', '//...')
+        try:
+            self.perforce.run_revert('-w', '//...')
+        except P4Exception:
+            # client might not exist yet, or not have any changes in either case that's fine
+            pass
 
         self.perforce.save_client(client)
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -124,6 +124,9 @@ class P4Repo:
         # unless overidden, overwrite writeable-but-unopened files
         # (e.g. interrupted syncs, artefacts that have been checked-in)
         client._options = self.client_options + ' clobber'
+        
+        # revert changes in client before saving to avoid an error if files are still open in client
+        self.revert()
 
         self.perforce.save_client(client)
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -128,8 +128,9 @@ class P4Repo:
         # revert changes in client before saving to avoid an error if files are still open in client
         try:
             self.perforce.run_revert('-w', '//...')
-        except P4Exception:
+        except P4Exception as ex:
             # client might not exist yet, or not have any changes in either case that's fine
+            self.perforce.logger.warning("%s" % ex)
             pass
 
         self.perforce.save_client(client)


### PR DESCRIPTION
Attempting to avoid the following error which presents if a workspace has open files:

P4.P4Exception: [P4#run] Errors during command execution( "p4 client -i" )	
[Error]: "Client 'bk-p4-bk-95e7e0fc01359405a1a535adf3dbbc8135025a92-c5hk-1-midwinter' has files opened; use -f to force switch."