### PR TITLE
Fixing the failed unshelve exception printing

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -272,6 +272,8 @@ class P4Repo:
 
         changeinfo = self.perforce.run_describe('-S', changelist)
         if not changeinfo:
+            perforce.logger = self.perforce.logger
+            perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists")
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -275,10 +275,9 @@ class P4Repo:
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 
-        try:
-            depotfiles = changeinfo['depotFile']
-        except KeyError:
+        if 'depotFile' not in changeinfo:
             raise Exception('Changelist %s does not contain any shelved files' % changelist)
+        depotfiles = changeinfo['depotFile']
         
 
         whereinfo = self.perforce.run_where(depotfiles)

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -276,7 +276,12 @@ class P4Repo:
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 
-        depotfiles = changeinfo['depotFile']
+        if changeinfo['depotFile']:
+            depotfiles = changeinfo['depotFile']
+        else:
+            self.perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
+            raise Exception('Changelist %s does not contain any shelved files' % changelist)
+        
 
         whereinfo = self.perforce.run_where(depotfiles)
         depot_to_local = {item['depotFile']: item['path'] for item in whereinfo}

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -275,9 +275,9 @@ class P4Repo:
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 
-        if changeinfo['depotFile']:
+        try:
             depotfiles = changeinfo['depotFile']
-        else:
+        except KeyError:
             raise Exception('Changelist %s does not contain any shelved files' % changelist)
         
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -272,7 +272,6 @@ class P4Repo:
 
         changeinfo = self.perforce.run_describe('-S', changelist)
         if not changeinfo:
-            self.perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -278,7 +278,6 @@ class P4Repo:
         if changeinfo['depotFile']:
             depotfiles = changeinfo['depotFile']
         else:
-            self.perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
             raise Exception('Changelist %s does not contain any shelved files' % changelist)
         
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -269,12 +269,10 @@ class P4Repo:
     def p4print_unshelve(self, changelist):
         """Unshelve a pending change by p4printing the contents into a file"""
         self._setup_client()
-        perforce = P4()
 
         changeinfo = self.perforce.run_describe('-S', changelist)
         if not changeinfo:
-            perforce.logger = self.perforce.logger
-            perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
+            self.perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -274,7 +274,7 @@ class P4Repo:
         changeinfo = self.perforce.run_describe('-S', changelist)
         if not changeinfo:
             perforce.logger = self.perforce.logger
-            perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists")
+            perforce.logger.error("Changelist %s does not exist: Check to see if the shelved changelist still exists" % changelist)
             raise Exception('Changelist %s does not contain any shelved files.' % changelist)
         changeinfo = changeinfo[0]
 

--- a/python/perforce.py
+++ b/python/perforce.py
@@ -269,6 +269,7 @@ class P4Repo:
     def p4print_unshelve(self, changelist):
         """Unshelve a pending change by p4printing the contents into a file"""
         self._setup_client()
+        perforce = P4()
 
         changeinfo = self.perforce.run_describe('-S', changelist)
         if not changeinfo:


### PR DESCRIPTION
People were struggling with the error messaging when preflight job was kicked off and the changelist was accidentally empty.

The old error message looked like this:
![image](https://user-images.githubusercontent.com/11972560/123866001-6b0a2400-d8e1-11eb-931f-4c2a3be12eef.png)

The new error will look like this:
![image](https://user-images.githubusercontent.com/11972560/123866071-7e1cf400-d8e1-11eb-82c9-9bc4deb2616a.png)

The actual desired exception message is now reached

