### PR TITLE
fix(workspace re-use): use client_type to check if writeable

### DIFF
--- a/python/perforce.py
+++ b/python/perforce.py
@@ -163,7 +163,7 @@ class P4Repo:
             if prev_clientname != clientname:
                 need_full_clean = True
                 bless_version_file = os.path.join(self.root, "bless.version")
-                if client == "writeable":
+                if self.client_type == "writeable":
                     self.perforce.logger.warning("p4config last client was %s, flushing workspace to match" % prev_clientname)
                     self._flush_to_previous_client(client, prev_clientname)
                     need_full_clean = False


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
use client_type to check if writeable

## Verification

<!-- How you tested it? How do you know it works? -->
`test_client_migration` is failing on master, and it passes after this change
