### PR TITLE
fix(tests): terminate p4d after pytest

### DIFF
--- a/python/test_perforce.py
+++ b/python/test_perforce.py
@@ -52,7 +52,11 @@ def run_p4d(p4port, from_zip=None):
     os.chmod(os.path.join(p4ssldir, 'certificate.txt'), 0o600)
     os.environ['P4SSLDIR'] = p4ssldir
 
-    yield subprocess.Popen(['p4d', '-r', tmpdir, '-p', p4port])
+    try:
+        p4d = subprocess.Popen(['p4d', '-r', tmpdir, '-p', p4port])
+        yield p4d
+    finally:
+        p4d.terminate()
 
 @pytest.fixture(scope='package')
 def server():


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
terminate p4d after pytest

## Verification

<!-- How you tested it? How do you know it works? -->
when running the unit tests on master, there was a `p4d` process still running on my machine which I had to terminate manually, and it's now terminated automatically after the tests
