### PR TITLE
docs: add workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests Status](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/main.yml/badge.svg)](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/main.yml?query=branch%3Amaster)
 
-[![Tests Status](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml?query=branch%3Amaster)
+[![CodeQL Status](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml?query=branch%3Amaster)
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that lets you check out code from [Perforce Version Control](https://www.perforce.com/products/helix-core) on Windows, Linux and macOS platforms.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Perforce Buildkite Plugin [![Build Status](https://travis-ci.com/improbable-eng/perforce-buildkite-plugin.svg?branch=master)](https://travis-ci.com/improbable-eng/perforce-buildkite-plugin)
+# Perforce Buildkite Plugin
+
+[![Tests Status](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/main.yml/badge.svg)](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/main.yml?query=branch%3Amaster)
+
+[![Tests Status](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/improbable-eng/perforce-buildkite-plugin/actions/workflows/codeql-analysis.yml?query=branch%3Amaster)
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that lets you check out code from [Perforce Version Control](https://www.perforce.com/products/helix-core) on Windows, Linux and macOS platforms.
 


### PR DESCRIPTION
## Changes

add workflow status badges
remove obsolete build status

## Verification

looked at the markdown preview, clicked on the new links
